### PR TITLE
Fix: SAS token URL format in Azure Blob service

### DIFF
--- a/common/services/storage_services/azure_blob.py
+++ b/common/services/storage_services/azure_blob.py
@@ -68,7 +68,7 @@ class AzureBlobStorageService(StorageService):
                 expiry=expiry_time,
                 content_disposition=f"attachment; filename={filename}",
             )
-            return f"{container_client.url}?{sas_token}"
+            return f"{container_client.url}/{key}?{sas_token}"
 
     @classmethod
     async def check_object_exists(cls, key: str) -> bool:


### PR DESCRIPTION
Hello 👋, 
I noticed that the pre signed URL for downloading minutes via the frontend from Azure blob storage wasn't fully formed.

The proposed change is tested and working in our environment.