### PR TITLE
update location of pydantic models for db related schemas in README

### DIFF
--- a/alembic/README.md
+++ b/alembic/README.md
@@ -4,7 +4,7 @@ example uses a persistent data store using postgresql, running in a docker conta
 
 Models for the database are kept in `common/database/postgres_models.py`.
 
-Pydantic models for the database interaction are kept in `common/database/pydantic_schemas.py`.
+Pydantic models for the database interaction are kept in `common/types.py`.
 
 A function interface for interacting with the database is kept in `common/database/postgres_interface.py`.
 


### PR DESCRIPTION
Hi there, was just browsing the repo (I'm an MHCLG data scientist) and think I've spotted an error in the README; it states that the pydantic models are held in `common/database/pydantic_schemas.py` but I don't think that file exists anymore?

If I'm not wrong, those pydantic models are now held in `common/types.py`?

This PR makes this update.