### PR TITLE
Add unique email constraints and deduplication logic

### DIFF
--- a/alembic/versions/c4f9d2a1b8e3_dedupe_users_by_email_case.py
+++ b/alembic/versions/c4f9d2a1b8e3_dedupe_users_by_email_case.py
@@ -84,7 +84,10 @@ def upgrade() -> None:
 
     # Matches the Index declared on User.__table_args__ in common/database/postgres_models.py
     op.create_index("ix_user_email_lower", "user", [sa.text("lower(email)")], unique=True)
+    # add 30 days server default to data retention
+    op.alter_column("user", "data_retention_days", server_default="30")
 
 
 def downgrade() -> None:
     op.drop_index("ix_user_email_lower", table_name="user")
+    op.alter_column("user", "data_retention_days", server_default=None)

--- a/alembic/versions/c4f9d2a1b8e3_dedupe_users_by_email_case.py
+++ b/alembic/versions/c4f9d2a1b8e3_dedupe_users_by_email_case.py
@@ -1,0 +1,113 @@
+"""dedupe users by case-insensitive email and enforce uniqueness
+
+Revision ID: c4f9d2a1b8e3
+Revises: 9d080ca9fe6c
+Create Date: 2026-05-28 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "c4f9d2a1b8e3"
+down_revision: Union[str, None] = "9d080ca9fe6c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Reassign all FK references from duplicate (case-variant) users to the
+    # oldest user row sharing the same lowercase email, then drop the duplicates.
+    # The auth refactor may have switched email providers, and the new provider returns
+    # emails in a different case than the old one — that silently created a
+    # second User row for each affected person, orphaning their transcriptions.
+
+    # first query - update transcription table
+    # 1) canonical selects oldest lower case user email
+    # 2) remap query finds user IDs in transcription table where the normalised email case matches, but the ID is
+    # different
+    # 3) we then
+
+    op.execute(
+        """
+        WITH canonical AS (
+            SELECT DISTINCT ON (LOWER(email))
+                id AS keep_id,
+                LOWER(email) AS lower_email
+            FROM "user"
+            ORDER BY LOWER(email), created_datetime ASC, id ASC
+        ),
+        remap AS (
+            SELECT u.id AS old_id, c.keep_id
+            FROM "user" u
+            JOIN canonical c ON LOWER(u.email) = c.lower_email
+            WHERE u.id <> c.keep_id
+        )
+        UPDATE transcription t
+        SET user_id = r.keep_id
+        FROM remap r
+        WHERE t.user_id = r.old_id;
+        """
+    )
+    op.execute(
+        """
+        WITH canonical AS (
+            SELECT DISTINCT ON (LOWER(email))
+                id AS keep_id,
+                LOWER(email) AS lower_email
+            FROM "user"
+            ORDER BY LOWER(email), created_datetime ASC, id ASC
+        ),
+        remap AS (
+            SELECT u.id AS old_id, c.keep_id
+            FROM "user" u
+            JOIN canonical c ON LOWER(u.email) = c.lower_email
+            WHERE u.id <> c.keep_id
+        )
+        UPDATE recording r
+        SET user_id = rm.keep_id
+        FROM remap rm
+        WHERE r.user_id = rm.old_id;
+        """
+    )
+    op.execute(
+        """
+        WITH canonical AS (
+            SELECT DISTINCT ON (LOWER(email))
+                id AS keep_id,
+                LOWER(email) AS lower_email
+            FROM "user"
+            ORDER BY LOWER(email), created_datetime ASC, id ASC
+        ),
+        remap AS (
+            SELECT u.id AS old_id, c.keep_id
+            FROM "user" u
+            JOIN canonical c ON LOWER(u.email) = c.lower_email
+            WHERE u.id <> c.keep_id
+        )
+        UPDATE user_template ut
+        SET user_id = r.keep_id
+        FROM remap r
+        WHERE ut.user_id = r.old_id;
+        """
+    )
+    op.execute(
+        """
+        DELETE FROM "user" u
+        USING (
+            SELECT DISTINCT ON (LOWER(email)) id AS keep_id, LOWER(email) AS lower_email
+            FROM "user"
+            ORDER BY LOWER(email), created_datetime ASC, id ASC
+        ) c
+        WHERE LOWER(u.email) = c.lower_email AND u.id <> c.keep_id;
+        """
+    )
+
+    op.execute('UPDATE "user" SET email = LOWER(email) WHERE email <> LOWER(email);')
+
+    op.execute('CREATE UNIQUE INDEX ix_user_email_lower ON "user" (LOWER(email));')
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_user_email_lower;")

--- a/alembic/versions/c4f9d2a1b8e3_dedupe_users_by_email_case.py
+++ b/alembic/versions/c4f9d2a1b8e3_dedupe_users_by_email_case.py
@@ -16,6 +16,10 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+# Tables with a user_id FK that we need to re-point at the canonical user.
+TABLES_WITH_USER_FK = ("transcription", "recording", "user_template")
+
+
 def upgrade() -> None:
     # Reassign all FK references from duplicate (case-variant) users to the
     # oldest user row sharing the same lowercase email, then drop the duplicates.
@@ -23,86 +27,39 @@ def upgrade() -> None:
     # emails in a different case than the old one — that silently created a
     # second User row for each affected person, orphaning their transcriptions.
 
-    # first query - update transcription table
-    # 1) canonical selects oldest lower case user email
-    # 2) remap query finds user IDs in transcription table where the normalised email case matches, but the ID is
-    # different
-    # 3) we then update the transcription table by setting user_id to the User.id we want
+    # Build a remap (old_id -> keep_id) once, in a temp table, then reuse it
+    # for every FK update below. The ON COMMIT DROP removes the temp table at the end of the migration
+    # 1) canonical picks the oldest row for each lowercase email as the "keeper"
+    # 2) user_remap lists every non-keeper user paired with its keeper
 
     op.execute(
         """
+        CREATE TEMP TABLE user_remap ON COMMIT DROP AS
         WITH canonical AS (
             SELECT DISTINCT ON (LOWER(email))
                 id AS keep_id,
                 LOWER(email) AS lower_email
             FROM "user"
             ORDER BY LOWER(email), created_datetime ASC, id ASC
-        ),
-        remap AS (
-            SELECT u.id AS old_id, c.keep_id
-            FROM "user" u
-            JOIN canonical c ON LOWER(u.email) = c.lower_email
-            WHERE u.id <> c.keep_id
         )
-        UPDATE transcription t
-        SET user_id = r.keep_id
-        FROM remap r
-        WHERE t.user_id = r.old_id;
+        SELECT u.id AS old_id, c.keep_id
+        FROM "user" u
+        JOIN canonical c ON LOWER(u.email) = c.lower_email
+        WHERE u.id <> c.keep_id;
         """
     )
-    op.execute(
-        """
-        WITH canonical AS (
-            SELECT DISTINCT ON (LOWER(email))
-                id AS keep_id,
-                LOWER(email) AS lower_email
-            FROM "user"
-            ORDER BY LOWER(email), created_datetime ASC, id ASC
-        ),
-        remap AS (
-            SELECT u.id AS old_id, c.keep_id
-            FROM "user" u
-            JOIN canonical c ON LOWER(u.email) = c.lower_email
-            WHERE u.id <> c.keep_id
+
+    for table in TABLES_WITH_USER_FK:
+        op.execute(
+            f"""
+            UPDATE {table}
+            SET user_id = user_remap.keep_id
+            FROM user_remap
+            WHERE {table}.user_id = user_remap.old_id;
+            """
         )
-        UPDATE recording r
-        SET user_id = rm.keep_id
-        FROM remap rm
-        WHERE r.user_id = rm.old_id;
-        """
-    )
-    op.execute(
-        """
-        WITH canonical AS (
-            SELECT DISTINCT ON (LOWER(email))
-                id AS keep_id,
-                LOWER(email) AS lower_email
-            FROM "user"
-            ORDER BY LOWER(email), created_datetime ASC, id ASC
-        ),
-        remap AS (
-            SELECT u.id AS old_id, c.keep_id
-            FROM "user" u
-            JOIN canonical c ON LOWER(u.email) = c.lower_email
-            WHERE u.id <> c.keep_id
-        )
-        UPDATE user_template ut
-        SET user_id = r.keep_id
-        FROM remap r
-        WHERE ut.user_id = r.old_id;
-        """
-    )
-    op.execute(
-        """
-        DELETE FROM "user" u
-        USING (
-            SELECT DISTINCT ON (LOWER(email)) id AS keep_id, LOWER(email) AS lower_email
-            FROM "user"
-            ORDER BY LOWER(email), created_datetime ASC, id ASC
-        ) c
-        WHERE LOWER(u.email) = c.lower_email AND u.id <> c.keep_id;
-        """
-    )
+
+    op.execute('DELETE FROM "user" WHERE id IN (SELECT old_id FROM user_remap);')
 
     op.execute('UPDATE "user" SET email = LOWER(email) WHERE email <> LOWER(email);')
 

--- a/alembic/versions/c4f9d2a1b8e3_dedupe_users_by_email_case.py
+++ b/alembic/versions/c4f9d2a1b8e3_dedupe_users_by_email_case.py
@@ -28,25 +28,32 @@ def upgrade() -> None:
     # emails in a different case than the old one — that silently created a
     # second User row for each affected person, orphaning their transcriptions.
 
-    # Build a remap (old_id -> keep_id) once, in a temp table, then reuse it
-    # for every FK update below. The ON COMMIT DROP removes the temp table at the end of the migration
-    # 1) canonical picks the oldest row for each lowercase email as the "keeper"
-    # 2) user_remap lists every non-keeper user paired with its keeper
-
+    # Build a remap (old_id -> keep_id, resolved_retention) once, in a temp table,
+    # then reuse it for every FK update below. The ON COMMIT DROP removes the temp
+    # table at the end of the migration.
+    # 1) groups picks the oldest row per lowercase email as the "keeper" and
+    #    computes the most generous retention across the group. NULL retention
+    #    means "indefinite" (the longest possible); if any row in the group is
+    #    NULL the merged user keeps NULL, otherwise we take the largest day count.
+    # 2) user_remap lists every non-keeper user paired with its keeper.
     op.execute(
         """
         CREATE TEMP TABLE user_remap ON COMMIT DROP AS
-        WITH canonical AS (
-            SELECT DISTINCT ON (LOWER(email))
-                id AS keep_id,
-                LOWER(email) AS lower_email
+        WITH groups AS (
+            SELECT
+                LOWER(email) AS lower_email,
+                (array_agg(id ORDER BY created_datetime ASC, id ASC))[1] AS keep_id,
+                CASE WHEN COUNT(*) <> COUNT(data_retention_days)
+                     THEN NULL
+                     ELSE MAX(data_retention_days)
+                END AS resolved_retention
             FROM "user"
-            ORDER BY LOWER(email), created_datetime ASC, id ASC
+            GROUP BY LOWER(email)
         )
-        SELECT u.id AS old_id, c.keep_id
+        SELECT u.id AS old_id, g.keep_id, g.resolved_retention
         FROM "user" u
-        JOIN canonical c ON LOWER(u.email) = c.lower_email
-        WHERE u.id <> c.keep_id;
+        JOIN groups g ON LOWER(u.email) = g.lower_email
+        WHERE u.id <> g.keep_id;
         """
     )
 
@@ -59,6 +66,17 @@ def upgrade() -> None:
             WHERE {table}.user_id = user_remap.old_id;
             """
         )
+
+    # Apply the resolved retention to the kept user. DISTINCT collapses the
+    # one-row-per-duplicate user_remap shape down to one row per keeper.
+    op.execute(
+        """
+        UPDATE "user" u
+        SET data_retention_days = m.resolved_retention
+        FROM (SELECT DISTINCT keep_id, resolved_retention FROM user_remap) m
+        WHERE u.id = m.keep_id;
+        """
+    )
 
     op.execute('DELETE FROM "user" WHERE id IN (SELECT old_id FROM user_remap);')
 

--- a/alembic/versions/c4f9d2a1b8e3_dedupe_users_by_email_case.py
+++ b/alembic/versions/c4f9d2a1b8e3_dedupe_users_by_email_case.py
@@ -27,7 +27,7 @@ def upgrade() -> None:
     # 1) canonical selects oldest lower case user email
     # 2) remap query finds user IDs in transcription table where the normalised email case matches, but the ID is
     # different
-    # 3) we then
+    # 3) we then update the transcription table by setting user_id to the User.id we want
 
     op.execute(
         """

--- a/alembic/versions/c4f9d2a1b8e3_dedupe_users_by_email_case.py
+++ b/alembic/versions/c4f9d2a1b8e3_dedupe_users_by_email_case.py
@@ -8,6 +8,7 @@ Create Date: 2026-05-28 00:00:00.000000
 
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 revision: str = "c4f9d2a1b8e3"
@@ -63,8 +64,9 @@ def upgrade() -> None:
 
     op.execute('UPDATE "user" SET email = LOWER(email) WHERE email <> LOWER(email);')
 
-    op.execute('CREATE UNIQUE INDEX ix_user_email_lower ON "user" (LOWER(email));')
+    # Matches the Index declared on User.__table_args__ in common/database/postgres_models.py
+    op.create_index("ix_user_email_lower", "user", [sa.text("lower(email)")], unique=True)
 
 
 def downgrade() -> None:
-    op.execute("DROP INDEX IF EXISTS ix_user_email_lower;")
+    op.drop_index("ix_user_email_lower", table_name="user")

--- a/backend/api/dependencies/get_current_user.py
+++ b/backend/api/dependencies/get_current_user.py
@@ -2,6 +2,7 @@ from typing import Annotated
 
 from fastapi import Depends, Header, HTTPException
 from sqlalchemy.dialects.postgresql import insert
+from sqlmodel import func
 
 from backend.api.dependencies.get_session import SQLSessionDep
 from common.auth import get_user_info
@@ -46,7 +47,7 @@ async def get_current_user(
             insert(User)
             .values(email=email)
             .on_conflict_do_update(
-                index_elements=[User.email],
+                index_elements=[func.lower(User.email)],
                 set_={User.email: User.email},  # no-op, just so RETURNING fires
             )
             .returning(User)

--- a/backend/api/dependencies/get_current_user.py
+++ b/backend/api/dependencies/get_current_user.py
@@ -30,7 +30,9 @@ async def get_current_user(
 
     try:
         user_auth_info = get_user_info(authorization)
-        email = user_auth_info.email
+        # Normalise email — different auth providers return different casing,
+        # and we look users up by exact match, so a casing change orphans their data.
+        email = user_auth_info.email.lower()
 
         if not user_auth_info.is_authorised:
             logger.info("User {email} does not have the required permissions", email=email)

--- a/backend/api/dependencies/get_current_user.py
+++ b/backend/api/dependencies/get_current_user.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 
 from fastapi import Depends, Header, HTTPException
-from sqlmodel import select
+from sqlalchemy.dialects.postgresql import insert
 
 from backend.api.dependencies.get_session import SQLSessionDep
 from common.auth import get_user_info
@@ -42,19 +42,19 @@ async def get_current_user(
                 headers={"WWW-Authenticate": "Bearer"},
             )
 
-        # Try to find existing user
+        stmt = (
+            insert(User)
+            .values(email=email)
+            .on_conflict_do_update(
+                index_elements=[User.email],
+                set_={User.email: User.email},  # no-op, just so RETURNING fires
+            )
+            .returning(User)
+        )
+        result = await session.execute(stmt)
+        await session.commit()
 
-        statement = select(User).where(User.email == email)
-        user = (await session.exec(statement)).first()
-
-        if not user:
-            # Create new user if doesn't exist
-            user = User(email=email)
-            session.add(user)
-            await session.commit()
-            await session.refresh(user)
-
-        return user
+        return result.scalar_one()
     except MissingAuthTokenError as e:
         logger.warning("No authorization header provided")
         raise HTTPException(

--- a/common/database/postgres_models.py
+++ b/common/database/postgres_models.py
@@ -3,7 +3,7 @@ from enum import StrEnum, auto
 from typing import TypedDict
 from uuid import UUID, uuid4
 
-from sqlalchemy import TIMESTAMP, Column
+from sqlalchemy import TIMESTAMP, Column, Index, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped
 from sqlalchemy.sql.functions import now
@@ -113,6 +113,10 @@ class Hallucination(BaseTableMixin, table=True):
 # Main models with table=True for DB tables
 class User(BaseTableMixin, table=True):
     __tablename__ = "user"
+    # Case-insensitive uniqueness on email — emails are stored lowercased
+    # (see backend/api/dependencies/get_current_user.py), but this guards
+    # against accidental case-variant duplicates regardless.
+    __table_args__ = (Index("ix_user_email_lower", text("lower(email)"), unique=True),)
     created_datetime: datetime = Field(sa_column=created_datetime_column(), default=None)
     updated_datetime: datetime = Field(sa_column=updated_datetime_column(), default=None)
     email: str = Field(index=True)

--- a/common/database/postgres_models.py
+++ b/common/database/postgres_models.py
@@ -120,7 +120,7 @@ class User(BaseTableMixin, table=True):
     created_datetime: datetime = Field(sa_column=created_datetime_column(), default=None)
     updated_datetime: datetime = Field(sa_column=updated_datetime_column(), default=None)
     email: str = Field(index=True)
-    data_retention_days: int | None = Field(default=30)
+    data_retention_days: int | None = Field(default=30, sa_column_kwargs={"server_default": "30"})
     transcriptions: list["Transcription"] = Relationship(back_populates="user")
 
 

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -11,7 +11,7 @@ module "rds" {
   ]
   vpc_id                = data.terraform_remote_state.vpc.outputs.vpc_id
   engine                = "aurora-postgresql"
-  engine_version        = "16.8"
+  engine_version        = "16.11"
   family                = null
   engine_mode           = "provisioned"
   aurora_min_scaling    = 0.5

--- a/tests/test_migration_dedupe_users_by_email_case.py
+++ b/tests/test_migration_dedupe_users_by_email_case.py
@@ -75,6 +75,9 @@ def migration_db(monkeypatch):
 ALICE_OLDEST = uuid.UUID("11111111-1111-1111-1111-111111111111")
 ALICE_MIDDLE = uuid.UUID("22222222-2222-2222-2222-222222222222")
 ALICE_NEWEST = uuid.UUID("33333333-3333-3333-3333-333333333333")
+# Exact-case duplicate of ALICE_OLDEST's email — covers identical (not just
+# case-variant) duplicate rows, which can exist before the unique index lands.
+ALICE_EXACT_DUP = uuid.UUID("77777777-7777-7777-7777-777777777777")
 BOB = uuid.UUID("44444444-4444-4444-4444-444444444444")
 CAROL_NO_CHILDREN = uuid.UUID("55555555-5555-5555-5555-555555555555")
 CAROL_DUP = uuid.UUID("66666666-6666-6666-6666-666666666666")
@@ -83,6 +86,7 @@ TRANS_ON_ALICE_OLDEST = uuid.UUID("a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1")
 TRANS_ON_ALICE_MIDDLE = uuid.UUID("a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2")
 TRANS_ON_ALICE_NEWEST_1 = uuid.UUID("a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3")
 TRANS_ON_ALICE_NEWEST_2 = uuid.UUID("a4a4a4a4-a4a4-a4a4-a4a4-a4a4a4a4a4a4")
+TRANS_ON_ALICE_EXACT_DUP = uuid.UUID("a5a5a5a5-a5a5-a5a5-a5a5-a5a5a5a5a5a5")
 TRANS_ON_BOB = uuid.UUID("b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1")
 
 REC_ON_ALICE_MIDDLE = uuid.UUID("c1c1c1c1-c1c1-c1c1-c1c1-c1c1c1c1c1c1")
@@ -103,6 +107,7 @@ def _seed(conn: sa.Connection) -> None:
             """
             INSERT INTO "user" (id, email, created_datetime, updated_datetime, data_retention_days) VALUES
               (:a_old,   'Alice@Example.com', '2025-01-01 00:00:00+00', '2025-01-01 00:00:00+00', NULL),
+              (:a_dup,   'Alice@Example.com', '2025-01-20 00:00:00+00', '2025-01-20 00:00:00+00', 14),
               (:a_mid,   'alice@example.com', '2025-02-01 00:00:00+00', '2025-02-01 00:00:00+00', 30),
               (:a_new,   'ALICE@EXAMPLE.COM', '2025-03-01 00:00:00+00', '2025-03-01 00:00:00+00', 7),
               (:bob,     'bob@example.com',   '2025-01-15 00:00:00+00', '2025-01-15 00:00:00+00', NULL),
@@ -112,6 +117,7 @@ def _seed(conn: sa.Connection) -> None:
         ),
         {
             "a_old": ALICE_OLDEST,
+            "a_dup": ALICE_EXACT_DUP,
             "a_mid": ALICE_MIDDLE,
             "a_new": ALICE_NEWEST,
             "bob": BOB,
@@ -125,6 +131,7 @@ def _seed(conn: sa.Connection) -> None:
             """
             INSERT INTO transcription (id, user_id, created_datetime, updated_datetime) VALUES
               (:t_old,    :a_old, NOW(), NOW()),
+              (:t_dup,    :a_dup, NOW(), NOW()),
               (:t_mid,    :a_mid, NOW(), NOW()),
               (:t_new_1,  :a_new, NOW(), NOW()),
               (:t_new_2,  :a_new, NOW(), NOW()),
@@ -133,11 +140,13 @@ def _seed(conn: sa.Connection) -> None:
         ),
         {
             "t_old": TRANS_ON_ALICE_OLDEST,
+            "t_dup": TRANS_ON_ALICE_EXACT_DUP,
             "t_mid": TRANS_ON_ALICE_MIDDLE,
             "t_new_1": TRANS_ON_ALICE_NEWEST_1,
             "t_new_2": TRANS_ON_ALICE_NEWEST_2,
             "t_bob": TRANS_ON_BOB,
             "a_old": ALICE_OLDEST,
+            "a_dup": ALICE_EXACT_DUP,
             "a_mid": ALICE_MIDDLE,
             "a_new": ALICE_NEWEST,
             "bob": BOB,
@@ -208,6 +217,7 @@ def test_migration_merges_duplicates_reassigns_fks_and_lowercases(migration_db):
         )
         assert set(alice_trans) == {
             TRANS_ON_ALICE_OLDEST,
+            TRANS_ON_ALICE_EXACT_DUP,
             TRANS_ON_ALICE_MIDDLE,
             TRANS_ON_ALICE_NEWEST_1,
             TRANS_ON_ALICE_NEWEST_2,

--- a/tests/test_migration_dedupe_users_by_email_case.py
+++ b/tests/test_migration_dedupe_users_by_email_case.py
@@ -1,0 +1,314 @@
+"""Integration test for migration c4f9d2a1b8e3 (dedupe users by email case).
+
+Spins up a throwaway Postgres database, runs alembic up to the parent revision,
+seeds synthetic case-variant duplicates plus their child rows, applies the
+migration, and asserts that the merge, FK reassignment, lowercasing, and
+unique-index enforcement all behave correctly.
+
+Requires a running Postgres instance reachable via the POSTGRES_* settings
+(e.g. `docker-compose up postgres`). The connecting user needs CREATEDB.
+"""
+
+import uuid
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError, OperationalError
+
+import common.database.postgres_database as pgdb
+from alembic import command
+from alembic.config import Config
+from common.settings import get_settings
+
+PRE_REVISION = "9d080ca9fe6c"
+TARGET_REVISION = "c4f9d2a1b8e3"
+
+settings = get_settings()
+
+
+def _url(db_name: str) -> str:
+    return (
+        f"postgresql+psycopg2://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}"
+        f"@{settings.POSTGRES_HOST}:{settings.POSTGRES_PORT}/{db_name}"
+    )
+
+
+@pytest.fixture
+def migration_db(monkeypatch):
+    """Create a throwaway DB at PRE_REVISION; yield (engine, alembic Config); drop after."""
+    maintenance_engine = sa.create_engine(_url("postgres"), isolation_level="AUTOCOMMIT")
+    try:
+        with maintenance_engine.connect() as conn:
+            conn.execute(sa.text("SELECT 1"))
+    except OperationalError:
+        pytest.skip("Postgres is not reachable; this test requires docker-compose Postgres running.")
+
+    test_db_name = f"minute_mig_test_{uuid.uuid4().hex[:10]}"
+    with maintenance_engine.connect() as conn:
+        conn.execute(sa.text(f'CREATE DATABASE "{test_db_name}"'))
+
+    # Point both the project's engine and alembic env at the throwaway DB.
+    test_engine = sa.create_engine(_url(test_db_name))
+    monkeypatch.setattr(pgdb, "engine", test_engine)
+
+    cfg = Config("alembic.ini")
+    command.upgrade(cfg, PRE_REVISION)
+
+    try:
+        yield test_engine, cfg
+    finally:
+        test_engine.dispose()
+        with maintenance_engine.connect() as conn:
+            # Kill any lingering connections before dropping.
+            conn.execute(
+                sa.text(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = :name AND pid <> pg_backend_pid()"
+                ),
+                {"name": test_db_name},
+            )
+            conn.execute(sa.text(f'DROP DATABASE IF EXISTS "{test_db_name}"'))
+        maintenance_engine.dispose()
+
+
+# Fixed UUIDs make assertions easy to read.
+ALICE_OLDEST = uuid.UUID("11111111-1111-1111-1111-111111111111")
+ALICE_MIDDLE = uuid.UUID("22222222-2222-2222-2222-222222222222")
+ALICE_NEWEST = uuid.UUID("33333333-3333-3333-3333-333333333333")
+BOB = uuid.UUID("44444444-4444-4444-4444-444444444444")
+CAROL_NO_CHILDREN = uuid.UUID("55555555-5555-5555-5555-555555555555")
+CAROL_DUP = uuid.UUID("66666666-6666-6666-6666-666666666666")
+
+TRANS_ON_ALICE_OLDEST = uuid.UUID("a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1")
+TRANS_ON_ALICE_MIDDLE = uuid.UUID("a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2")
+TRANS_ON_ALICE_NEWEST_1 = uuid.UUID("a3a3a3a3-a3a3-a3a3-a3a3-a3a3a3a3a3a3")
+TRANS_ON_ALICE_NEWEST_2 = uuid.UUID("a4a4a4a4-a4a4-a4a4-a4a4-a4a4a4a4a4a4")
+TRANS_ON_BOB = uuid.UUID("b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1")
+
+REC_ON_ALICE_MIDDLE = uuid.UUID("c1c1c1c1-c1c1-c1c1-c1c1-c1c1c1c1c1c1")
+REC_ON_ALICE_NEWEST = uuid.UUID("c2c2c2c2-c2c2-c2c2-c2c2-c2c2c2c2c2c2")
+REC_ON_BOB = uuid.UUID("c3c3c3c3-c3c3-c3c3-c3c3-c3c3c3c3c3c3")
+
+TEMPLATE_ON_ALICE_NEWEST = uuid.UUID("d1d1d1d1-d1d1-d1d1-d1d1-d1d1d1d1d1d1")
+
+
+def _seed(conn: sa.Connection) -> None:
+    """Insert the synthetic fixture.
+
+    Three case-variant Alice rows, one Bob (untouched), and a Carol duplicate
+    with no child rows (exercises the merge-with-nothing-to-reassign path).
+    """
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO "user" (id, email, created_datetime, updated_datetime, data_retention_days) VALUES
+              (:a_old,   'Alice@Example.com', '2025-01-01 00:00:00+00', '2025-01-01 00:00:00+00', NULL),
+              (:a_mid,   'alice@example.com', '2025-02-01 00:00:00+00', '2025-02-01 00:00:00+00', 30),
+              (:a_new,   'ALICE@EXAMPLE.COM', '2025-03-01 00:00:00+00', '2025-03-01 00:00:00+00', 7),
+              (:bob,     'bob@example.com',   '2025-01-15 00:00:00+00', '2025-01-15 00:00:00+00', NULL),
+              (:carol_a, 'Carol@x.com',       '2024-12-01 00:00:00+00', '2024-12-01 00:00:00+00', NULL),
+              (:carol_b, 'carol@x.com',       '2025-04-01 00:00:00+00', '2025-04-01 00:00:00+00', 90);
+            """
+        ),
+        {
+            "a_old": ALICE_OLDEST,
+            "a_mid": ALICE_MIDDLE,
+            "a_new": ALICE_NEWEST,
+            "bob": BOB,
+            "carol_a": CAROL_NO_CHILDREN,
+            "carol_b": CAROL_DUP,
+        },
+    )
+
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO transcription (id, user_id, created_datetime, updated_datetime) VALUES
+              (:t_old,    :a_old, NOW(), NOW()),
+              (:t_mid,    :a_mid, NOW(), NOW()),
+              (:t_new_1,  :a_new, NOW(), NOW()),
+              (:t_new_2,  :a_new, NOW(), NOW()),
+              (:t_bob,    :bob,   NOW(), NOW());
+            """
+        ),
+        {
+            "t_old": TRANS_ON_ALICE_OLDEST,
+            "t_mid": TRANS_ON_ALICE_MIDDLE,
+            "t_new_1": TRANS_ON_ALICE_NEWEST_1,
+            "t_new_2": TRANS_ON_ALICE_NEWEST_2,
+            "t_bob": TRANS_ON_BOB,
+            "a_old": ALICE_OLDEST,
+            "a_mid": ALICE_MIDDLE,
+            "a_new": ALICE_NEWEST,
+            "bob": BOB,
+        },
+    )
+
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO recording (id, user_id, s3_file_key, created_datetime) VALUES
+              (:r_mid, :a_mid, 'k-mid', NOW()),
+              (:r_new, :a_new, 'k-new', NOW()),
+              (:r_bob, :bob,   'k-bob', NOW());
+            """
+        ),
+        {
+            "r_mid": REC_ON_ALICE_MIDDLE,
+            "r_new": REC_ON_ALICE_NEWEST,
+            "r_bob": REC_ON_BOB,
+            "a_mid": ALICE_MIDDLE,
+            "a_new": ALICE_NEWEST,
+            "bob": BOB,
+        },
+    )
+
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO user_template
+              (id, user_id, name, content, description, type, created_datetime, updated_datetime)
+            VALUES
+              (:t, :u, 'Notes', '<p>x</p>', '', 'DOCUMENT', NOW(), NOW());
+            """
+        ),
+        {"t": TEMPLATE_ON_ALICE_NEWEST, "u": ALICE_NEWEST},
+    )
+
+
+def test_migration_merges_duplicates_reassigns_fks_and_lowercases(migration_db):
+    engine, cfg = migration_db
+
+    with engine.begin() as conn:
+        _seed(conn)
+
+    command.upgrade(cfg, TARGET_REVISION)
+
+    with engine.connect() as conn:
+        rows = conn.execute(sa.text('SELECT id, email FROM "user" ORDER BY created_datetime')).all()
+        ids_by_email = {r.email: r.id for r in rows}
+
+        # Three users remain: oldest Alice, Bob, oldest Carol.
+        assert {r.email for r in rows} == {"alice@example.com", "bob@example.com", "carol@x.com"}
+        assert ids_by_email["alice@example.com"] == ALICE_OLDEST
+        assert ids_by_email["carol@x.com"] == CAROL_NO_CHILDREN
+        assert ids_by_email["bob@example.com"] == BOB
+
+        # All emails are lowercased (even the ones that started lowercase, no-op).
+        assert all(r.email == r.email.lower() for r in rows)
+
+        # All four "Alice" transcriptions now point at the kept Alice.
+        alice_trans = (
+            conn.execute(
+                sa.text("SELECT id FROM transcription WHERE user_id = :u ORDER BY id"),
+                {"u": ALICE_OLDEST},
+            )
+            .scalars()
+            .all()
+        )
+        assert set(alice_trans) == {
+            TRANS_ON_ALICE_OLDEST,
+            TRANS_ON_ALICE_MIDDLE,
+            TRANS_ON_ALICE_NEWEST_1,
+            TRANS_ON_ALICE_NEWEST_2,
+        }
+
+        # Bob's transcription is untouched.
+        bob_trans = conn.execute(
+            sa.text("SELECT user_id FROM transcription WHERE id = :t"),
+            {"t": TRANS_ON_BOB},
+        ).scalar_one()
+        assert bob_trans == BOB
+
+        # Recordings reassigned to the kept Alice; Bob's untouched.
+        recs = conn.execute(sa.text("SELECT id, user_id FROM recording")).all()
+        rec_owner = {r.id: r.user_id for r in recs}
+        assert rec_owner[REC_ON_ALICE_MIDDLE] == ALICE_OLDEST
+        assert rec_owner[REC_ON_ALICE_NEWEST] == ALICE_OLDEST
+        assert rec_owner[REC_ON_BOB] == BOB
+
+        # User template reassigned to the kept Alice.
+        template_owner = conn.execute(
+            sa.text("SELECT user_id FROM user_template WHERE id = :t"),
+            {"t": TEMPLATE_ON_ALICE_NEWEST},
+        ).scalar_one()
+        assert template_owner == ALICE_OLDEST
+
+        # No FK references survive to deleted users.
+        # Table/column names are hardcoded in this loop, so the f-string is safe (noqa S608).
+        for table, col in [("transcription", "user_id"), ("recording", "user_id"), ("user_template", "user_id")]:
+            query = f'SELECT COUNT(*) FROM {table} WHERE {col} IS NOT NULL AND {col} NOT IN (SELECT id FROM "user")'  # noqa: S608
+            orphans = conn.execute(sa.text(query)).scalar_one()
+            assert orphans == 0, f"orphaned {table}.{col} rows after migration"
+
+
+def test_migration_enforces_case_insensitive_uniqueness(migration_db):
+    engine, cfg = migration_db
+    command.upgrade(cfg, TARGET_REVISION)
+
+    # Inserting a fresh user is fine.
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                'INSERT INTO "user" (id, email, created_datetime, updated_datetime) '
+                "VALUES (gen_random_uuid(), :e, NOW(), NOW())"
+            ),
+            {"e": "dave@example.com"},
+        )
+
+    # A case-variant of the same email is rejected by the functional unique index.
+    with pytest.raises(IntegrityError), engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                'INSERT INTO "user" (id, email, created_datetime, updated_datetime) '
+                "VALUES (gen_random_uuid(), :e, NOW(), NOW())"
+            ),
+            {"e": "DAVE@Example.com"},
+        )
+
+
+def test_migration_is_a_noop_when_there_are_no_duplicates(migration_db):
+    engine, cfg = migration_db
+
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                'INSERT INTO "user" (id, email, created_datetime, updated_datetime) ' "VALUES (:i, :e, NOW(), NOW())"
+            ),
+            {"i": BOB, "e": "bob@example.com"},
+        )
+
+    command.upgrade(cfg, TARGET_REVISION)
+
+    with engine.connect() as conn:
+        rows = conn.execute(sa.text('SELECT id, email FROM "user"')).all()
+        assert len(rows) == 1
+        assert rows[0].id == BOB
+        assert rows[0].email == "bob@example.com"
+
+
+def test_downgrade_drops_only_the_unique_index(migration_db):
+    engine, cfg = migration_db
+    command.upgrade(cfg, TARGET_REVISION)
+
+    # Seed a single user so we can verify rows survive the downgrade.
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                'INSERT INTO "user" (id, email, created_datetime, updated_datetime) ' "VALUES (:i, :e, NOW(), NOW())"
+            ),
+            {"i": BOB, "e": "bob@example.com"},
+        )
+
+    command.downgrade(cfg, PRE_REVISION)
+
+    with engine.connect() as conn:
+        # The unique index is gone.
+        present = conn.execute(
+            sa.text("SELECT 1 FROM pg_indexes WHERE schemaname = 'public' " "AND indexname = 'ix_user_email_lower'")
+        ).first()
+        assert present is None
+
+        # The user row is still there — downgrade does not un-merge.
+        rows = conn.execute(sa.text('SELECT email FROM "user"')).all()
+        assert {r.email for r in rows} == {"bob@example.com"}

--- a/tests/test_migration_dedupe_users_by_email_case.py
+++ b/tests/test_migration_dedupe_users_by_email_case.py
@@ -81,6 +81,9 @@ ALICE_EXACT_DUP = uuid.UUID("77777777-7777-7777-7777-777777777777")
 BOB = uuid.UUID("44444444-4444-4444-4444-444444444444")
 CAROL_NO_CHILDREN = uuid.UUID("55555555-5555-5555-5555-555555555555")
 CAROL_DUP = uuid.UUID("66666666-6666-6666-6666-666666666666")
+# Dave's duplicates all have finite retention so we exercise the MAX path.
+DAVE_OLDEST = uuid.UUID("88888888-8888-8888-8888-888888888888")
+DAVE_DUP = uuid.UUID("99999999-9999-9999-9999-999999999999")
 
 TRANS_ON_ALICE_OLDEST = uuid.UUID("a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1")
 TRANS_ON_ALICE_MIDDLE = uuid.UUID("a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2")
@@ -112,7 +115,9 @@ def _seed(conn: sa.Connection) -> None:
               (:a_new,   'ALICE@EXAMPLE.COM', '2025-03-01 00:00:00+00', '2025-03-01 00:00:00+00', 7),
               (:bob,     'bob@example.com',   '2025-01-15 00:00:00+00', '2025-01-15 00:00:00+00', NULL),
               (:carol_a, 'Carol@x.com',       '2024-12-01 00:00:00+00', '2024-12-01 00:00:00+00', NULL),
-              (:carol_b, 'carol@x.com',       '2025-04-01 00:00:00+00', '2025-04-01 00:00:00+00', 90);
+              (:carol_b, 'carol@x.com',       '2025-04-01 00:00:00+00', '2025-04-01 00:00:00+00', 90),
+              (:dave_a,  'Dave@x.com',        '2025-01-10 00:00:00+00', '2025-01-10 00:00:00+00', 7),
+              (:dave_b,  'dave@x.com',        '2025-03-10 00:00:00+00', '2025-03-10 00:00:00+00', 365);
             """
         ),
         {
@@ -123,6 +128,8 @@ def _seed(conn: sa.Connection) -> None:
             "bob": BOB,
             "carol_a": CAROL_NO_CHILDREN,
             "carol_b": CAROL_DUP,
+            "dave_a": DAVE_OLDEST,
+            "dave_b": DAVE_DUP,
         },
     )
 
@@ -194,17 +201,33 @@ def test_migration_merges_duplicates_reassigns_fks_and_lowercases(migration_db):
     command.upgrade(cfg, TARGET_REVISION)
 
     with engine.connect() as conn:
-        rows = conn.execute(sa.text('SELECT id, email FROM "user" ORDER BY created_datetime')).all()
+        rows = conn.execute(
+            sa.text('SELECT id, email, data_retention_days FROM "user" ORDER BY created_datetime')
+        ).all()
         ids_by_email = {r.email: r.id for r in rows}
+        retention_by_email = {r.email: r.data_retention_days for r in rows}
 
-        # Three users remain: oldest Alice, Bob, oldest Carol.
-        assert {r.email for r in rows} == {"alice@example.com", "bob@example.com", "carol@x.com"}
+        # Four users remain: oldest Alice, Bob, oldest Carol, oldest Dave.
+        assert {r.email for r in rows} == {
+            "alice@example.com",
+            "bob@example.com",
+            "carol@x.com",
+            "dave@x.com",
+        }
         assert ids_by_email["alice@example.com"] == ALICE_OLDEST
         assert ids_by_email["carol@x.com"] == CAROL_NO_CHILDREN
         assert ids_by_email["bob@example.com"] == BOB
+        assert ids_by_email["dave@x.com"] == DAVE_OLDEST
 
         # All emails are lowercased (even the ones that started lowercase, no-op).
         assert all(r.email == r.email.lower() for r in rows)
+
+        # The longest retention from each duplicate group wins. NULL ("indefinite")
+        # beats any finite number; otherwise the largest day count.
+        assert retention_by_email["alice@example.com"] is None  # ALICE_OLDEST had NULL
+        assert retention_by_email["carol@x.com"] is None  # CAROL_NO_CHILDREN had NULL
+        assert retention_by_email["dave@x.com"] == 365  # MAX(7, 365)
+        assert retention_by_email["bob@example.com"] is None  # untouched (no duplicates)
 
         # All four "Alice" transcriptions now point at the kept Alice.
         alice_trans = (

--- a/tests/test_migration_dedupe_users_by_email_case.py
+++ b/tests/test_migration_dedupe_users_by_email_case.py
@@ -102,7 +102,7 @@ TEMPLATE_ON_ALICE_NEWEST = uuid.UUID("d1d1d1d1-d1d1-d1d1-d1d1-d1d1d1d1d1d1")
 def _seed(conn: sa.Connection) -> None:
     """Insert the synthetic fixture.
 
-    Three case-variant Alice rows, one Bob (untouched), and a Carol duplicate
+    Four case-variant Alice rows, one Bob (untouched), and a Carol duplicate
     with no child rows (exercises the merge-with-nothing-to-reassign path).
     """
     conn.execute(


### PR DESCRIPTION
This pull request introduces functionality to enforce unique email addresses in a case-insensitive manner. It includes the following changes:

- Added a unique index to enforce case-insensitive uniqueness for email addresses in the schema.
- Refactored migration logic to optimize the deduplication of user records and consolidated foreign key updates for better efficiency.
- Added a migration to merge duplicate accounts based on case-insensitive email deduplication criteria.
- Updated comments in the code for better clarity and understanding.

These changes improve data integrity and ensure consistency within the database.