### PR TITLE
Handle TOKEN_EXPIRED from Auth API

### DIFF
--- a/frontend/app/clear-cookies/route.tsx
+++ b/frontend/app/clear-cookies/route.tsx
@@ -9,6 +9,10 @@ export async function GET() {
   cookieStore.delete('AWSALBAuthNonce')
   cookieStore.set('SESSION_HAS_BEEN_REFRESHED', 'TRUE', {
     maxAge: SEVEN_DAYS_SECONDS,
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    path: '/',
   })
   redirect('/')
 }

--- a/frontend/app/clear-cookies/route.tsx
+++ b/frontend/app/clear-cookies/route.tsx
@@ -1,8 +1,14 @@
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
+
+const SEVEN_DAYS_SECONDS = 7 * 24 * 60 * 60
+
 export async function GET() {
   const cookieStore = cookies()
   cookieStore.delete('X-Amzn-Oidc-Data-0')
   cookieStore.delete('AWSALBAuthNonce')
+  cookieStore.set('SESSION_HAS_BEEN_REFRESHED', 'TRUE', {
+    maxAge: SEVEN_DAYS_SECONDS,
+  })
   redirect('/')
 }

--- a/frontend/app/clear-cookies/route.tsx
+++ b/frontend/app/clear-cookies/route.tsx
@@ -1,0 +1,8 @@
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+export async function GET() {
+  const cookieStore = cookies()
+  cookieStore.delete('X-Amzn-Oidc-Data-0')
+  cookieStore.delete('AWSALBAuthNonce')
+  redirect('/')
+}

--- a/frontend/app/clear-cookies/route.tsx
+++ b/frontend/app/clear-cookies/route.tsx
@@ -1,18 +1,9 @@
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 
-const SEVEN_DAYS_SECONDS = 7 * 24 * 60 * 60
-
 export async function GET() {
   const cookieStore = cookies()
   cookieStore.delete('X-Amzn-Oidc-Data-0')
   cookieStore.delete('AWSALBAuthNonce')
-  cookieStore.set('SESSION_HAS_BEEN_REFRESHED', 'TRUE', {
-    maxAge: SEVEN_DAYS_SECONDS,
-    httpOnly: true,
-    secure: true,
-    sameSite: 'lax',
-    path: '/',
-  })
   redirect('/')
 }

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -51,7 +51,9 @@ export async function middleware(req: NextRequest) {
         authReason: 'LOCAL_TESTING',
       }
     }
-
+    if (authResult?.authReason === 'TOKEN_EXPIRED') {
+      return signoutAndRedirect(req)
+    }
     if (authResult?.isAuthorised !== true) {
       console.error(`User is not authorised to access ${pathname}`)
       return redirectToUnauthorised(req)
@@ -79,7 +81,13 @@ function redirectToGenericError(req: NextRequest) {
   url.pathname = '/generic-error'
   return NextResponse.redirect(url)
 }
-
+function signoutAndRedirect(req: NextRequest) {
+  req.cookies.delete('X-Amzn-Oidc-Data-0')
+  req.cookies.delete('AWSALBAuthNonce')
+  const url = req.nextUrl.clone()
+  url.pathname = '/'
+  return NextResponse.redirect(url)
+}
 // Configure which paths this middleware should run on
 export const config = {
   matcher: [

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -11,6 +11,7 @@ const PUBLIC_PATHS = [
   '/monitoring',
   '/privacy',
   '/support',
+  '/clear-cookies',
 ]
 
 export async function middleware(req: NextRequest) {
@@ -51,10 +52,10 @@ export async function middleware(req: NextRequest) {
         authReason: 'LOCAL_TESTING',
       }
     }
-    if (authResult?.authReason === 'TOKEN_EXPIRED') {
-      return signoutAndRedirect(req)
-    }
     if (authResult?.isAuthorised !== true) {
+      if (authResult?.authReason === 'TOKEN_EXPIRED') {
+        return signoutAndRedirect(req)
+      }
       console.error(`User is not authorised to access ${pathname}`)
       return redirectToUnauthorised(req)
     }
@@ -82,10 +83,8 @@ function redirectToGenericError(req: NextRequest) {
   return NextResponse.redirect(url)
 }
 function signoutAndRedirect(req: NextRequest) {
-  req.cookies.delete('X-Amzn-Oidc-Data-0')
-  req.cookies.delete('AWSALBAuthNonce')
   const url = req.nextUrl.clone()
-  url.pathname = '/'
+  url.pathname = '/clear-cookies'
   return NextResponse.redirect(url)
 }
 // Configure which paths this middleware should run on

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -53,14 +53,11 @@ export async function middleware(req: NextRequest) {
       }
     }
     if (authResult?.isAuthorised !== true) {
+      if (authResult?.authReason === 'TOKEN_EXPIRED') {
+        return redirectToClearCookies(req)
+      }
       console.error(`User is not authorised to access ${pathname}`)
       return redirectToUnauthorised(req)
-    }
-    const session_refreshed_cookie = req.cookies.get(
-      'SESSION_HAS_BEEN_REFRESHED'
-    )
-    if (!session_refreshed_cookie) {
-      return redirectToClearCookies(req)
     }
 
     console.info(

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -53,11 +53,14 @@ export async function middleware(req: NextRequest) {
       }
     }
     if (authResult?.isAuthorised !== true) {
-      if (authResult?.authReason === 'TOKEN_EXPIRED') {
-        return signoutAndRedirect(req)
-      }
       console.error(`User is not authorised to access ${pathname}`)
       return redirectToUnauthorised(req)
+    }
+    const session_refreshed_cookie = req.cookies.get(
+      'SESSION_HAS_BEEN_REFRESHED'
+    )
+    if (!session_refreshed_cookie) {
+      return redirectToClearCookies(req)
     }
 
     console.info(
@@ -82,7 +85,7 @@ function redirectToGenericError(req: NextRequest) {
   url.pathname = '/generic-error'
   return NextResponse.redirect(url)
 }
-function signoutAndRedirect(req: NextRequest) {
+function redirectToClearCookies(req: NextRequest) {
   const url = req.nextUrl.clone()
   url.pathname = '/clear-cookies'
   return NextResponse.redirect(url)


### PR DESCRIPTION
Need to force users who have TOKEN_EXPIRED to refresh their tokens, so we clear their cookies using the /clear-cookies route, and redirect them to the homepage