### PR TITLE
Add custom 403 page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,8 +43,9 @@ Brewfile.lock.json
 *.html
 !frontend/content/*.html
 !frontend/public-site/**/*.html
-*_files/
+!terraform/waf_block_page/index.html
 
+*_files/
 # Docker cache
 .build-cache
 
@@ -111,3 +112,6 @@ config/google-credentials.json
 /test-results/
 /playwright-report/
 /playwright/.cache/
+
+certs/
+.tmp/

--- a/terraform/load_balancer.tf
+++ b/terraform/load_balancer.tf
@@ -14,7 +14,7 @@ module "load_balancer" {
 module "waf" {
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
   #source                      = "../../i-dot-ai-core-terraform-modules//modules/infrastructure/waf" # For testing local changes
-  source      = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/waf?ref=v7.3.1-waf"
+  source      = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/waf?ref=v8.0.0-waf"
   name        = local.name
   host        = local.host
   env         = var.env
@@ -24,6 +24,8 @@ module "waf" {
     header_name  = "x-custom-edge-router"
     secret_value = data.aws_ssm_parameter.edge_secret[0].value
   } : null
+
+  custom_block_page_path = "${path.module}/waf_block_page/index.html"
 }
 
 resource "aws_route53_record" "type_a_record" {

--- a/terraform/waf_block_page/index.html
+++ b/terraform/waf_block_page/index.html
@@ -69,7 +69,7 @@
     <main class="content">
       <h1>Access denied</h1>
       <p>This may be because you are accessing the app at our old URL (minute.ai.cabinetoffice.gov.uk). If so, please
-        use our new URL at <a href="https://minute.i.ai.gov.uk/" rel="noopener noreferrer">extract.i.ai.gov.uk</a>.</p>
+        use our new URL at <a href="https://minute.i.ai.gov.uk/" rel="noopener noreferrer">minute.i.ai.gov.uk</a>.</p>
       <p>Alternatively, you may not have been allowed on our system. If you think this is a mistake, please contact
         i.AI.</p>
     </main>

--- a/terraform/waf_block_page/index.html
+++ b/terraform/waf_block_page/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8">
+  <title>Access denied</title>
+  <style>
+    body {
+      font-family: sans-serif;
+    }
+
+    .container {
+      padding: 20px;
+      padding-bottom: 0px;
+      border: 1px solid #cccccc;
+      border-radius: 10px;
+      max-width: 600px;
+      margin: auto;
+    }
+
+    .header {
+      text-align: center;
+      padding: 10px;
+      margin-bottom: 0px;
+    }
+
+    .logo {
+      display: inline-block;
+      padding-left: 12px;
+      border-left: 3px solid #000;
+      text-align: left;
+      text-decoration: none;
+      color: #000;
+      line-height: 1.1;
+    }
+
+    .logo__title {
+      font-size: 1.92em;
+      font-weight: bold;
+      letter-spacing: -0.05em;
+    }
+
+    .logo__subtitle {
+      font-size: 1.44em;
+    }
+
+    .content {
+      padding: 20px;
+      font-size: 16px;
+      line-height: 1.5;
+    }
+
+    h1 {
+      font-size: 1.5rem;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="container">
+    <header class="header">
+      <div class="logo">
+        <span class="logo__title">i.AI</span><br>
+        <span class="logo__subtitle">Incubator for</span><br>
+        <span class="logo__subtitle">Artificial Intelligence</span>
+      </div>
+    </header>
+    <main class="content">
+      <h1>Access denied</h1>
+      <p>This may be because you are accessing the app at our old URL (minute.ai.cabinetoffice.gov.uk). If so, please
+        use our new URL at <a href="https://minute.i.ai.gov.uk/" rel="noopener noreferrer">extract.i.ai.gov.uk</a>.</p>
+      <p>Alternatively, you may not have been allowed on our system. If you think this is a mistake, please contact
+        i.AI.</p>
+    </main>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
Add a custom 403 page to explain error when landing on wrong url from non whitelisted ip address

<img width="790" height="438" alt="Screenshot 2026-06-25 at 13 17 09" src="https://github.com/user-attachments/assets/42378221-07c1-4526-83ea-52ef14a492a1" />
