### PR TITLE
Remove stickiness form main toolbars, move to just editing bar and au…

### DIFF
--- a/frontend/app/transcriptions/[transcriptionId]/MinuteTab/MinuteTab.tsx
+++ b/frontend/app/transcriptions/[transcriptionId]/MinuteTab/MinuteTab.tsx
@@ -69,7 +69,7 @@ export function MinuteTab({
   }
   return (
     <>
-      <div className="top-0 z-10 border-b border-(--govuk-border-colour) bg-[#8eb8dc] px-[20px] pt-[30px] pb-[10px] sm:sticky sm:mx-[-20px] sm:mt-[-30px]">
+      <div className="border-b border-(--govuk-border-colour) bg-[#8eb8dc] px-[20px] pt-[30px] pb-[10px] sm:mx-[-20px] sm:mt-[-30px]">
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop">
             <div className="govuk-form-group govuk-!-margin-bottom-2">

--- a/frontend/app/transcriptions/[transcriptionId]/MinuteTab/components/editor/tiptap-editor.tsx
+++ b/frontend/app/transcriptions/[transcriptionId]/MinuteTab/components/editor/tiptap-editor.tsx
@@ -182,7 +182,7 @@ function SimpleEditor({
   return (
     <div>
       {isEditing && (
-        <div className="flex items-center justify-between border-b border-gray-300 bg-gray-50 p-2">
+        <div className="sticky top-0 z-10 flex items-center justify-between border-b border-gray-300 bg-gray-50 p-2">
           <div className="flex items-center">
             <div className="mr-4 flex space-x-1">
               <button

--- a/frontend/app/transcriptions/[transcriptionId]/TranscriptionTab/TranscriptionTab.tsx
+++ b/frontend/app/transcriptions/[transcriptionId]/TranscriptionTab/TranscriptionTab.tsx
@@ -140,7 +140,7 @@ export function TranscriptionTab({
                 />
               </div>
               <div className="govuk-grid-column-one-third">
-                <div className="govuk-button-group govuk-!-margin-top-2 govuk-!-margin-bottom-0">
+                <div className="govuk-button-group govuk-!-margin-top-1 govuk-!-margin-bottom-0">
                   <button
                     type="button"
                     onClick={scrollToPlaying}

--- a/frontend/app/transcriptions/[transcriptionId]/TranscriptionTab/TranscriptionTab.tsx
+++ b/frontend/app/transcriptions/[transcriptionId]/TranscriptionTab/TranscriptionTab.tsx
@@ -83,7 +83,7 @@ export function TranscriptionTab({
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(saveTranscription)}>
-        <div className="top-0 z-10 border-b border-(--govuk-border-colour) bg-[#8eb8dc] px-[20px] pt-[30px] pb-[10px] sm:sticky sm:mx-[-20px] sm:mt-[-30px]">
+        <div className="bg-[#8eb8dc] px-[20px] pt-[30px] pb-[10px] sm:mx-[-20px] sm:mt-[-30px]">
           <div className="govuk-grid-row">
             <div className="govuk-grid-column-two-thirds">
               <div className="govuk-button-group govuk-!-margin-bottom-0">
@@ -98,14 +98,34 @@ export function TranscriptionTab({
                 {hasRecordings && (
                   <DownloadButton recordings={recordings} inverse={true} />
                 )}
-                <button
-                  onClick={scrollToPlaying}
-                  className="govuk-button govuk-button--inverse"
-                >
-                  <ArrowDown className="size-4" /> Scroll to current section
-                </button>
               </div>
-              {hasRecordings && (
+              <p className="govuk-body-s govuk-!-margin-bottom-1">
+                If you rename a speaker, you must re-generate the summary to use
+                the new names.
+              </p>
+            </div>
+            <div className="govuk-grid-column-one-third">
+              <div>
+                <p className="govuk-body-s govuk-!-margin-bottom-1 flex gap-2">
+                  <PencilIcon className="inline-block size-4" /> Click a name to
+                  rename it.
+                </p>
+                <p className="govuk-body-s govuk-!-margin-bottom-1 flex gap-2">
+                  <SquarePen className="inline-block size-4" /> Click any text
+                  box to edit the text.
+                </p>
+                <p className="govuk-body-s govuk-!-margin-bottom-1 flex gap-2">
+                  <Play className="inline-block size-4" /> Click a timestamp to
+                  play from that point.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        {hasRecordings && (
+          <div className="sticky top-0 z-10 border-b border-(--govuk-border-colour) bg-[#8eb8dc] px-[20px] py-[10px] sm:mx-[-20px]">
+            <div className="govuk-grid-row">
+              <div className="govuk-grid-column-two-thirds">
                 <audio
                   controls
                   src={recordings[0].url}
@@ -118,39 +138,21 @@ export function TranscriptionTab({
                     }
                   }}
                 />
-              )}
-            </div>
-            <div className="govuk-grid-column-one-third">
-              <div>
-                <p className="govuk-body-s govuk-!-margin-bottom-1">
-                  If you rename a speaker, you must re-generate the summary to
-                  use the new names.
-                </p>
-                <p className="govuk-body-s govuk-!-margin-bottom-1 flex gap-2">
-                  <PencilIcon className="size-4" /> Click a name to rename it.
-                </p>
-                <p className="govuk-body-s govuk-!-margin-bottom-1 flex gap-2">
-                  <SquarePen className="size-4" /> Click any text box to edit
-                  the text.
-                </p>
-                <p className="govuk-body-s govuk-!-margin-bottom-1 flex gap-2">
-                  <Play className="size-4" /> Click a timestamp to play from
-                  that point.
-                </p>
+              </div>
+              <div className="govuk-grid-column-one-third">
+                <div className="govuk-button-group govuk-!-margin-top-2 govuk-!-margin-bottom-0">
+                  <button
+                    type="button"
+                    onClick={scrollToPlaying}
+                    className="govuk-button govuk-button--inverse"
+                  >
+                    <ArrowDown className="size-4" /> Scroll to current section
+                  </button>
+                </div>
               </div>
             </div>
           </div>
-          <div className="govuk-grid-row">
-            {hasRecordings && (
-              <>
-                <div className="govuk-grid-column-two-thirds"></div>
-                <div className="govuk-grid-column-one-third">
-                  <div className="govuk-button-group govuk-!-margin-top-2 govuk-!-margin-bottom-0"></div>
-                </div>
-              </>
-            )}
-          </div>
-        </div>
+        )}
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-full">
             <div className="flex flex-col gap-6">


### PR DESCRIPTION
…dio bar
The current issue is on small screens the majority of the screen was taken up by a sticky tool bar

## Previously
<img width="838" height="940" alt="Screenshot 2026-06-25 at 14 21 07" src="https://github.com/user-attachments/assets/4e136927-aab7-4d83-9cfe-febd5c534ad8" />

## Implementation
Make the main bar not sticky - However makes sense to keep the editing bar when showing as sticky


<img width="1572" height="982" alt="Screenshot 2026-06-25 at 14 20 41" src="https://github.com/user-attachments/assets/9f8e920e-ca5d-40d9-bdd3-753bc06813f7" />

Also rearrange the transcript tab so that the audio can be sticky

<img width="1596" height="898" alt="Screenshot 2026-06-25 at 14 20 33" src="https://github.com/user-attachments/assets/9620d093-20e1-43ac-ab24-443d38a5d79d" />
<img width="1554" height="1293" alt="Screenshot 2026-06-25 at 14 20 29" src="https://github.com/user-attachments/assets/fe59b49a-4f6c-4336-8b98-8870ecb865be" />
