### PR TITLE
fix: quadratic regex hang in American-to-British spelling conversion

### DIFF
--- a/common/convert_american_to_british_spelling.py
+++ b/common/convert_american_to_british_spelling.py
@@ -5,6 +5,27 @@ from breame.spelling import american_spelling_exists, get_british_spelling
 
 logger = logging.getLogger(__name__)
 
+# The pattern must start with the letter class so that positions with no following
+# letters fail in O(1). A lazy non-letter prefix group re-expands to the end of the
+# string at every position of a trailing non-letter run (e.g. a markdown table),
+# making the scan quadratic and effectively hanging on large documents.
+WORD_PATTERN = re.compile(r"[a-zA-Z]+")
+
+
+def _is_ascii_letter(char: str) -> bool:
+    return "a" <= char <= "z" or "A" <= char <= "Z"
+
+
+def _preceded_by_backtick(text: str, word_start: int) -> bool:
+    # Look for a backtick in the run of non-letter characters before the word,
+    # e.g. the opening fence of a code span
+    i = word_start - 1
+    while i >= 0 and not _is_ascii_letter(text[i]):
+        if text[i] == "`":
+            return True
+        i -= 1
+    return False
+
 
 def convert_american_to_british_spelling(  # noqa: C901
     text: str, strict: bool = False
@@ -14,37 +35,31 @@ def convert_american_to_british_spelling(  # noqa: C901
 
     try:
 
-        def replace_word(match):
-            # The first group contains any leading punctuation/spaces
-            # The second group contains the word
-            # The third group contains any trailing punctuation/spaces
-            pre, word, post = match.groups()
+        def replace_word(match: re.Match) -> str:
+            word = match.group(0)
+
+            if not american_spelling_exists(word.lower()):
+                return word
 
             # Skip if within code blocks
-            if "`" in pre or "`" in post:
-                return match.group(0)
+            if _preceded_by_backtick(text, match.start()):
+                return word
 
-            if american_spelling_exists(word.lower()):
-                try:
-                    british = get_british_spelling(word.lower())
-                    # Preserve capitalization
-                    if word.isupper():
-                        british = british.upper()
-                    elif word.istitle():
-                        british = british.title()
-                    return pre + british + post
-                except Exception as e:
-                    logger.warning("Failed to convert word '%s': %s", word, e)
-                    if strict:
-                        raise
-            return match.group(0)
+            try:
+                british = get_british_spelling(word.lower())
+                # Preserve capitalization
+                if word.isupper():
+                    british = british.upper()
+                elif word.istitle():
+                    british = british.title()
+                return british
+            except Exception as e:
+                logger.warning("Failed to convert word '%s': %s", word, e)
+                if strict:
+                    raise
+            return word
 
-        # Match any word surrounded by non-letter characters
-        # Group 1: Leading non-letters (including empty)
-        # Group 2: The word itself (only letters)
-        # Group 3: Trailing non-letters (including empty)
-        pattern = r"([^a-zA-Z]*?)([a-zA-Z]+)([^a-zA-Z]*?)"
-        return re.sub(pattern, replace_word, text)
+        return WORD_PATTERN.sub(replace_word, text)
 
     except Exception:
         logger.exception("Failed to convert text")

--- a/common/services/minute_handler_service.py
+++ b/common/services/minute_handler_service.py
@@ -60,11 +60,11 @@ class MinuteHandlerService:
                 err_msg = f"MinuteVersion not found for id: {minute_version_id}"
                 raise ValueError(err_msg)
 
-            if html_content:
+            if html_content is not None:
                 minute_version.html_content = html_content
             if status:
                 minute_version.status = status
-            if error:
+            if error is not None:
                 minute_version.error = error
             if hallucinations:
                 minute_version.hallucinations = [
@@ -73,6 +73,16 @@ class MinuteHandlerService:
                 ]
             session.add(minute_version)
             session.commit()
+
+    @classmethod
+    def record_minute_version_failure(cls, minute_version_id: UUID, error: str) -> None:
+        # A failure here must not mask the original error, otherwise the caller raises
+        # something other than MinuteGenerationFailedError and the queue message is
+        # never completed, causing endless redelivery
+        try:
+            cls.update_minute_version(minute_version_id, status=JobStatus.FAILED, error=error)
+        except Exception:
+            logger.exception("Failed to record FAILED status for MinuteVersion %s", minute_version_id)
 
     @classmethod
     async def get_minute_version(cls, minute_version_id: UUID) -> MinuteVersion:
@@ -130,7 +140,8 @@ class MinuteHandlerService:
                 status=JobStatus.COMPLETED,
             )
         except Exception as e:
-            cls.update_minute_version(minute_version.id, status=JobStatus.FAILED, error=str(e))
+            logger.exception("%s: Minute generation failed", minute_version.minute_id)
+            cls.record_minute_version_failure(minute_version.id, error=str(e))
             raise MinuteGenerationFailedError from e
 
     @classmethod
@@ -162,7 +173,8 @@ class MinuteHandlerService:
             )
 
         except Exception as e:
-            cls.update_minute_version(target_minute_version.id, status=JobStatus.FAILED, error=str(e))
+            logger.exception("%s: Minute edit failed", target_minute_version.minute_id)
+            cls.record_minute_version_failure(target_minute_version.id, error=str(e))
             raise MinuteGenerationFailedError from e
 
     @classmethod

--- a/tests/test_convert_american_to_british_spelling.py
+++ b/tests/test_convert_american_to_british_spelling.py
@@ -1,4 +1,6 @@
 # ruff: noqa: S101
+import time
+
 from common.convert_american_to_british_spelling import convert_american_to_british_spelling
 
 
@@ -73,6 +75,23 @@ def test_mixed_valid_invalid_with_punctuation():
     text = "Is this color xyzabc? The theater has qwerty!"
     expected = "Is this colour xyzabc? The theatre has qwerty!"
     assert convert_american_to_british_spelling(text) == expected
+
+
+def test_markdown_table_with_convertible_words():
+    """Test that words in markdown tables are converted and table syntax is preserved."""
+    text = "| color | theater |\n|---|---|\n| 1.23 | 4,567 |"
+    expected = "| colour | theatre |\n|---|---|\n| 1.23 | 4,567 |"
+    assert convert_american_to_british_spelling(text) == expected
+
+
+def test_large_trailing_non_letter_run_is_fast():
+    """Regression test: a long trailing run of non-letter characters (e.g. a numeric
+    markdown table) caused quadratic regex backtracking that hung the worker."""
+    text = "The color is gray. " + "| 123 | 4.56 | 789 |\n" * 2500  # ~50KB non-letter tail
+    start = time.perf_counter()
+    result = convert_american_to_british_spelling(text)
+    assert time.perf_counter() - start < 5
+    assert result.startswith("The colour is grey. ")
 
 
 def test_markdown_syntax():


### PR DESCRIPTION
The lazy non-letter prefix group in the conversion pattern made re.sub quadratic on long runs of non-letter characters (e.g. numeric markdown tables in LLM output). A large generated minute could spin the LLM actor's event loop indefinitely after generation, so the minute_version row was never updated, the SQS message was never completed, and worker heartbeats stopped. Rewritten as a linear word scan with the same conversion and inline-code behaviour, plus a regression test.

Also harden the worker persistence path: the FAILED-status write in the error branch is now wrapped so a DB failure there can't mask the original error or turn a handled failure into an endless redelivery loop, and empty-string html_content is no longer silently dropped.