### PR TITLE
Update maximum filesize upload due to next 15 upgrade

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -2,6 +2,10 @@ import { withSentryConfig } from '@sentry/nextjs'
 
 let nextConfig = {
   output: 'standalone',
+  experimental: {
+    // 5GB matches limits on deployed environments
+    middlewareClientMaxBodySize: 5 * 1024 * 1024 * 1024,
+  },
   webpack: (config) => {
     config.module.rules.push({
       test: /\.html$/,


### PR DESCRIPTION
## Problem

In local dev when uploading a file above 10mb we hit an internal next middleware issue:
This was caused when moving from Next 14 to Next 15

```
Request body exceeded 10MB for /api/proxy/mock_storage/uploadfile/restricted/user-uploads/test@test.co.uk/ea82e741-2f3c-4671-98dd-99734d891574.mp4. Only the first 10MB will be available unless configured. See https://nextjs.org/docs/app/api-reference/config/next-config-js/middlewareClientMaxBodySize for more details.
Failed to proxy http://localhost:8080/mock_storage/uploadfile/restricted/user-uploads/test@test.co.uk/ea82e741-2f3c-4671-98dd-99734d891574.mp4 [Error: socket hang up] { code: 'ECONNRESET' }
[Error: socket hang up] { code: 'ECONNRESET' }
```

## Fix

Fix is to increase the maxbody size in next config. Moved to 5gb to match limit in deployed environments