### PR TITLE
bugfix: fix template spacing with long descriptions

### DIFF
--- a/frontend/app/templates/components/user-templates-list.tsx
+++ b/frontend/app/templates/components/user-templates-list.tsx
@@ -164,7 +164,7 @@ const TemplateListItem = ({ template }: { template: TemplateResponse }) => {
       key={template.id}
       className="transcriptions__list-item govuk-!-padding-top-3 govuk-!-padding-bottom-3 flex items-start justify-between"
     >
-      <div>
+      <div className="flex-1">
         <h4 className="govuk-heading-s govuk-!-margin-bottom-1">
           <Link className="govuk-link" href={`/templates/${template.id}`}>
             {template.name || 'Untitled template'}


### PR DESCRIPTION
# Spacing issue with templates with long descriptions

Buttons stack if the description is too long on templates

<img width="862" height="340" alt="Screenshot 2026-08-14 at 09 11 54" src="https://github.com/user-attachments/assets/e4056ccd-da25-4b2c-890c-c844a7a98283" />

## Fix

Make first container flex grow to fill space without forcing the buttons into two lines

<img width="874" height="385" alt="Screenshot 2026-08-14 at 09 57 40" src="https://github.com/user-attachments/assets/bc6335c8-8e64-4690-8e23-5504f0159c6b" />
