### PR TITLE
fix action item formatting in general templates

### DIFF
--- a/common/templates/default/general.py
+++ b/common/templates/default/general.py
@@ -52,6 +52,11 @@ Writing Guidelines:
     - Include relevant context where it aids understanding
     - Maintain appropriate level of detail based on topic importance
 
+Formatting:
+    - Render lists as markdown bullet points, with each item starting with "- " on its own line
+    - This applies especially to Action Items and Next Steps: put each item on a separate bullet, never combine multiple items onto one line
+    - Separate distinct list items with a line break so they render as individual bullets
+
 Remember to:
     - Emphasise outcomes and decisions over process
     - Clearly distinguish between decisions made and items requiring further discussion


### PR DESCRIPTION
Have had repeated feedback from users that the action items were coming back in single lines

For example:

<img width="1355" height="216" alt="image" src="https://github.com/user-attachments/assets/eb01f8ae-6337-4702-abf4-12bc9c8e849b" />

## Notes

I couldn't replicate, but have seen previously. I think it is from the action items coming as single lines without a dash which gets formatted into a single p tag

I have tightened up the prompt adding a formatting prompt to the general template prompt in a similar vein to the planning committee style guide