### PR TITLE
fix: keep General template minutes renderable after the Gemini 3.5 switch

### DIFF
--- a/common/prompts.py
+++ b/common/prompts.py
@@ -138,15 +138,18 @@ Add citations to the provided meeting summary which reference items in the trans
 
 <formatting_instructions>
 Each citation should be of the form [n] where n is the index of the transcript item. Each citation should be one number surrounded by square brackets. For example, you must do [80][81] not [80, 81].
+Do not wrap citations in backticks or any other code formatting: write [80], never `[80]`.
 </formatting_instructions>
 
 <requirements>
 Each statement should have a maximum of 5 citations.
 Do not add citations to lists of attendees.
+Reproduce the summary's Markdown exactly as given: the same headings, bullets, bold text, tables and line breaks. Adding citations is the only change you may make.
 </requirements>
 
 <output>
 Output the meeting summary unchanged except for the addition of citations.
+Start your response with the first line of the summary. Do not add a preamble, a sign-off, or any commentary about what you have done.
 </output>
 """,
         }

--- a/common/services/minute_handler_service.py
+++ b/common/services/minute_handler_service.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import uuid
 from typing import cast
 from uuid import UUID
@@ -31,6 +32,19 @@ logger = logging.getLogger(__name__)
 
 class MinuteGenerationFailedError(Exception):
     pass
+
+
+fenced_document_pattern = re.compile(r"\A\s*```[a-zA-Z]*\n(.*?)\n?```\s*\Z", re.DOTALL)
+
+
+def strip_document_code_fence(markdown: str) -> str:
+    """Unwrap a whole minute that the model returned inside a code fence.
+
+    mistune turns a fence around the entire document into a single <pre><code> block, which renders
+    the minute as raw Markdown rather than as formatted text.
+    """
+    match = fenced_document_pattern.match(markdown)
+    return match.group(1) if match else markdown
 
 
 class MinuteHandlerService:
@@ -205,7 +219,7 @@ class MinuteHandlerService:
                 result, hallucinations = await cls.generate_basic_minutes(minute.transcription.dialogue_entries)
             case _:
                 result, hallucinations = await cls.generate_full_minutes(minute)
-        result = mistune.html(result)
+        result = mistune.html(strip_document_code_fence(result))
         return cast(str, result), hallucinations
 
     @classmethod

--- a/common/templates/citations.py
+++ b/common/templates/citations.py
@@ -14,9 +14,39 @@ async def add_citations_to_minute(
 
     minute = await chatbot.chat(messages)
 
-    minute = combine_consecutive_citations(minute)
+    minute = strip_preamble(initial_draft, minute or "")
+    minute = unwrap_backticked_citations(minute)
 
-    return minute or ""
+    return combine_consecutive_citations(minute)
+
+
+backticked_citation_pattern = re.compile(r"`{1,2}((?:\[\d+(?:-\d+)?\])+)`{1,2}")
+
+
+def strip_preamble(initial_draft: str, minute: str) -> str:
+    """Drop any commentary the model wrote before the summary itself.
+
+    The citations pass is asked to return the draft unchanged apart from the citations, but it
+    sometimes prefaces it with a line such as "Below are the updated meeting minutes". If the draft
+    opened with a Markdown heading then nothing can legitimately precede that heading, so anything
+    before the first one is the model talking about its own work.
+    """
+    if not initial_draft.lstrip().startswith("#"):
+        return minute
+    lines = minute.split("\n")
+    for i, line in enumerate(lines):
+        if line.startswith("#"):
+            return "\n".join(lines[i:])
+    return minute
+
+
+def unwrap_backticked_citations(minute: str) -> str:
+    """Remove code formatting from citations, e.g. `[3]` -> [3].
+
+    mistune renders a backticked citation as a <code> element, which the minute editor then shows as
+    monospace code rather than as part of the sentence.
+    """
+    return backticked_citation_pattern.sub(r"\1", minute)
 
 
 MAX_CITATION_DISTANCE = 2

--- a/common/templates/default/general.py
+++ b/common/templates/default/general.py
@@ -20,16 +20,16 @@ class General(SimpleTemplate):
         date = datetime.now(tz=ZoneInfo("Europe/London")).strftime("%d %B %Y")
 
         if not agenda:
-            meeting_agenda_str = """4. Discussion Points
+            meeting_agenda_str = """## 4. Discussion Points
 - Present in chronological order
-- Group related topics under clear subheadings
+- Group related topics under "### " subheadings
 - Include different perspectives and debates
 - Capture the reasoning behind discussions
 - Note any data or evidence presented
 - Highlight concerns raised and how they were addressed
 - Err on the side of including more detail rather than less"""
         else:
-            meeting_agenda_str = f"""4. Discussion Points
+            meeting_agenda_str = f"""## 4. Discussion Points
 - Include different perspectives and debates
 - Capture the reasoning behind discussions
 - Note any data or evidence presented
@@ -37,7 +37,7 @@ class General(SimpleTemplate):
 - Err on the side of including more detail rather than less
 
 These are the agenda items for this meeting. Do not include other items under the Discussion Points header.
-Use them as headings for the discussion points.:
+Use them as "### " subheadings for the discussion points.:
  - {'\n - '.join(topic for topic in agenda.splitlines())}
 
            """
@@ -52,10 +52,11 @@ Writing Guidelines:
     - Include relevant context where it aids understanding
     - Maintain appropriate level of detail based on topic importance
 
-Formatting:
-    - Render lists as markdown bullet points, with each item starting with "- " on its own line
-    - This applies especially to Action Items and Next Steps: put each item on a separate bullet, never combine multiple items onto one line
-    - Separate distinct list items with a line break so they render as individual bullets
+Output format:
+    - Write the minutes in Markdown, and use only these constructs: "# " for the title, "## " for each section heading below, "### " for subheadings within a section, "- " for bullets, and "**bold**" for emphasis
+    - Do not use tables, code fences, backticks or HTML. Action Items and Next Steps must be bullets, never a table
+    - Start every bullet with "- " on its own line. This applies especially to Action Items and Next Steps: put each item on a separate bullet, never combine multiple items onto one line
+    - Begin your response with the "# " title line. Do not add a preamble, a sign-off, or any commentary about the minutes themselves
 
 Remember to:
     - Emphasise outcomes and decisions over process
@@ -63,39 +64,42 @@ Remember to:
     - Maintain chronological flow while grouping related topics
     - Be precise with technical terms and proper nouns
 
-You should structure the minutes with these sections (omit any that aren't relevant to the meeting):
+Open the minutes with a "# " title derived from the content discussed, then use these section headings exactly as written below (omit any section that isn't relevant to the meeting):
 
-1. Meeting Overview
-   - Date: {date}
-   - Title (derive this from the content discussed)
-   - Purpose/Objective of the meeting (if discernible from the discussion)
+## 1. Meeting Overview
+- Date: {date}
+- Title (derive this from the content discussed)
+- Purpose/Objective of the meeting (if discernible from the discussion)
 
-2. Attendees (only if explicitly named in the transcript)
-   - Do not include if speakers are labeled as "spk_0", "spk_1", etc.
-   - Include roles/departments if mentioned
+## 2. Attendees
+- Include this section only if attendees are explicitly named in the transcript
+- Do not include if speakers are labeled as "spk_0", "spk_1", etc.
+- Include roles/departments if mentioned
 
-3. Executive Summary
-   - Brief 2-3 sentence overview of the meeting's key outcomes
-   - Highlight major decisions or significant discussion points
+## 3. Executive Summary
+- Brief 2-3 sentence overview of the meeting's key outcomes
+- Highlight major decisions or significant discussion points
 
 {meeting_agenda_str}
 
-5. Key Decisions
-   - Clear statement of each decision made
-   - Include context and rationale
-   - Note who made or approved each decision (if specified)
-   - Record any dissenting opinions
+## 5. Key Decisions
+- Clear statement of each decision made
+- Include context and rationale
+- Note who made or approved each decision (if specified)
+- Record any dissenting opinions
 
-6. Action Items
-   - List specific tasks assigned
-   - Include responsible parties (if identified)
-   - Note deadlines or timeframes
-   - Specify any dependencies or resources needed
+## 6. Action Items
+- One bullet per task, never a table
+- List specific tasks assigned
+- Include responsible parties (if identified)
+- Note deadlines or timeframes
+- Specify any dependencies or resources needed
 
-7. Next Steps
-   - Document any planned follow-up meetings
-   - Note upcoming milestones or deadlines
-   - List any pending items for future discussion"""
+## 7. Next Steps
+- One bullet per item, never a table
+- Document any planned follow-up meetings
+- Note upcoming milestones or deadlines
+- List any pending items for future discussion"""
         return [
             {
                 "role": "system",

--- a/tests/test_minute_formatting.py
+++ b/tests/test_minute_formatting.py
@@ -1,0 +1,78 @@
+"""Guards against model output that Markdown rendering turns into a broken minute."""
+
+import mistune
+
+from common.services.minute_handler_service import strip_document_code_fence
+from common.templates.citations import (
+    combine_consecutive_citations,
+    strip_preamble,
+    unwrap_backticked_citations,
+)
+
+DRAFT = """# Meeting Minutes: Delivery Board
+
+## 1. Meeting Overview
+
+- **Date:** 10 September 2026
+"""
+
+
+def test_strip_preamble_removes_commentary_before_the_first_heading():
+    minute = (
+        "An analysis of the transcript has been performed to map key details to the meeting summary. "
+        "Below are the updated meeting minutes with citations added.\n\n" + DRAFT
+    )
+    assert strip_preamble(DRAFT, minute) == DRAFT
+
+
+def test_strip_preamble_leaves_a_clean_minute_untouched():
+    assert strip_preamble(DRAFT, DRAFT) == DRAFT
+
+
+def test_strip_preamble_keeps_content_when_the_draft_does_not_start_with_a_heading():
+    """Templates that open with prose have no heading to anchor on, so nothing is dropped."""
+    draft = "The board met on 10 September 2026.\n\n## Actions\n"
+    minute = "Here are the minutes.\n\n" + draft
+    assert strip_preamble(draft, minute) == minute
+
+
+def test_strip_preamble_keeps_content_when_the_model_returns_no_heading():
+    minute = "The board met on 10 September 2026 [1]."
+    assert strip_preamble(DRAFT, minute) == minute
+
+
+def test_unwrap_backticked_citations():
+    minute = "The dry run finished on Friday `[1]`. Two findings were raised `[3-4][7]`."
+    expected = "The dry run finished on Friday [1]. Two findings were raised [3-4][7]."
+    assert unwrap_backticked_citations(minute) == expected
+
+
+def test_unwrap_backticked_citations_leaves_real_code_spans_alone():
+    minute = "Daniel wrote the `normalise_address` step [3]."
+    assert unwrap_backticked_citations(minute) == minute
+
+
+def test_backticked_citations_would_otherwise_render_as_code():
+    """The reason the unwrapping exists: mistune turns `[1]` into a <code> element."""
+    assert "<code>[1]</code>" in mistune.html("The dry run finished `[1]`.")
+    assert "<code>" not in mistune.html(unwrap_backticked_citations("The dry run finished `[1]`."))
+
+
+def test_combine_consecutive_citations_still_groups_runs():
+    minute = "A statement [1][2][3] and another [9]."
+    assert combine_consecutive_citations(minute) == "A statement [1-3] and another [9]."
+
+
+def test_strip_document_code_fence_unwraps_a_fenced_minute():
+    fenced = "```markdown\n# Meeting Minutes\n\n- A point\n```"
+    assert strip_document_code_fence(fenced) == "# Meeting Minutes\n\n- A point"
+
+
+def test_strip_document_code_fence_leaves_an_unfenced_minute_alone():
+    assert strip_document_code_fence(DRAFT) == DRAFT
+
+
+def test_fenced_minute_would_otherwise_render_as_one_code_block():
+    fenced = "```markdown\n# Meeting Minutes\n\n- A point\n```"
+    assert "<pre>" in mistune.html(fenced)
+    assert "<h1>" in mistune.html(strip_document_code_fence(fenced))


### PR DESCRIPTION
Minutes from the General template stopped rendering as well-formatted markdown after the move to `gemini-3.5-flash`. Running the template against the live model showed three separate artefacts, all of which survive into the stored `html_content`:

| Artefact | What the user sees |
| --- | --- |
| Action Items returned as a markdown table | mistune renders `<table>`; the minute editor has no table extension and `globals.css` has no table styles, so the section is dropped on load — and since the editor writes `getHTML()` back into the form, copy and Word export lose it too |
| Citations wrapped in backticks — `` `[1-2]` `` | mistune emits `<code>[1-2]</code>`, rendered red and monospace mid-sentence |
| The citations pass prefacing the document | *"Below are the updated meeting minutes with citations added"* stored as the minute's first paragraph |

General was the only template that never stated which markdown to emit. `cabinet.py`, `planning_committee.py` and `care_assessment_v2.py` all spell out their headings explicitly, and none of them regressed — Gemini 3.5 simply fills that silence differently from 2.5. This builds on #146, which addressed the same symptom at the prompt level.

## Changes

- **`common/templates/default/general.py`** — states the markdown constructs the model may use, shows the section headings literally as `## `, and rules out tables where Action Items and Next Steps are described.
- **`common/prompts.py`** — the citations pass must reproduce the draft's markdown exactly, must not wrap citations in backticks, and must not add commentary.
- **`common/templates/citations.py`** — prompts are advisory, so `strip_preamble()` drops anything before the first heading when the draft opened with one, and `unwrap_backticked_citations()` undoes `` `[3]` `` → `[3]`.
- **`common/services/minute_handler_service.py`** — `strip_document_code_fence()` unwraps a whole minute returned inside a code fence before mistune turns it into one `<pre><code>` block. The AI-edit path already had an equivalent guard; the generation path had none.
- **`tests/test_minute_formatting.py`** — 11 tests covering each guard, two of which pin the mistune behaviour that motivates them.

## Verification

Run end to end against `gemini-3.5-flash` with a synthetic transcript, before and after. The resulting HTML is now `<h1>`/`<h2>`/`<h3>` headings, `<ul>` bullets throughout including Action Items, `<strong>` labels and plain `[n]` citations — every element in the editor's schema, so nothing is dropped on load or export.

`ruff check` clean; 23 unit tests pass.

## Follow-ups, not in this PR

- `convert_american_to_british_spelling` turns **draft** into **draught** (`breame` maps the bare word; `drafted`/`drafting` are unaffected). It corrupts a word that appears in most government minutes and is unrelated to the model version.
- Tables are unrenderable app-wide, not just here: a user template containing a `<table>` goes through `markdownify` and hits the same missing TipTap extension, silently. Supporting them means adding `@tiptap/extension-table` plus GOV.UK table styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5hve8uYCvP4prC9LbFEK3
