### PR TITLE
Add posthog events

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,6 +7,7 @@ import { AudioDevice } from '@/components/audio/microphone-permission'
 import { useRecordingSession } from '@/providers/recording-session-provider'
 import { Mic, Video, Upload, Info, Settings2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import posthog from 'posthog-js'
 import { useState, useEffect, useRef } from 'react'
 import { useOfflineRecordings } from '@/components/recent-meetings/use-offline-recordings'
 import UrlMigrationBanner from '@/components/url-migration-banner'
@@ -68,6 +69,7 @@ export default function Home() {
         setMicDenied(false)
       } catch (error) {
         console.error(error)
+        posthog.capture('mic_start_failed', { source: 'record_page_init' })
         if (error instanceof DOMException && error.name === 'NotAllowedError') {
           setMicDenied(true)
         }
@@ -86,6 +88,7 @@ export default function Home() {
         session.setScreenStream(stream)
       } catch (error) {
         console.warn('Screen share cancelled or unavailable', error)
+        posthog.capture('screen_share_cancelled')
         return
       }
     }
@@ -242,7 +245,16 @@ export default function Home() {
                         page and allow access to the microphone.
                       </p>
                     </div>
-                    <details className="govuk-details">
+                    <details
+                      className="govuk-details"
+                      onToggle={(e) => {
+                        if (e.currentTarget.open) {
+                          posthog.capture('details_expanded', {
+                            which: 'mic_access_instructions',
+                          })
+                        }
+                      }}
+                    >
                       <summary className="govuk-details__summary">
                         <span className="govuk-details__summary-text">
                           Instructions to enable microphone access if problem
@@ -405,6 +417,13 @@ export default function Home() {
                       <details
                         className="govuk-details"
                         id="virtual-meeting-audio-not-picking-up"
+                        onToggle={(e) => {
+                          if (e.currentTarget.open) {
+                            posthog.capture('details_expanded', {
+                              which: 'audio_screenshare_not_picking_up',
+                            })
+                          }
+                        }}
                       >
                         <summary className="govuk-details__summary">
                           <span className="govuk-details__summary-text">

--- a/frontend/app/templates/components/delete-templates-dialog.tsx
+++ b/frontend/app/templates/components/delete-templates-dialog.tsx
@@ -13,7 +13,7 @@ import { getUserTemplatesUserTemplatesGetQueryKey } from '@/lib/client/@tanstack
 import { deleteUserTemplateUserTemplatesTemplateIdDelete } from '@/lib/client/sdk.gen'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import posthog from 'posthog-js'
-import { Dispatch, SetStateAction } from 'react'
+import { Dispatch, SetStateAction, useRef } from 'react'
 
 export const DeleteTemplatesDialog = ({
   open,
@@ -28,6 +28,7 @@ export const DeleteTemplatesDialog = ({
 }) => {
   const queryClient = useQueryClient()
   const count = templateIds.length
+  const confirmedRef = useRef(false)
   const { mutate: deleteTemplates, isPending } = useMutation({
     mutationFn: async (ids: string[]) => {
       await Promise.all(
@@ -48,8 +49,20 @@ export const DeleteTemplatesDialog = ({
     },
   })
 
+  const handleOpenChange = (next: boolean) => {
+    if (!next && !confirmedRef.current) {
+      posthog.capture('delete_modal_cancelled', {
+        entity_type: 'template',
+        bulk: true,
+        count,
+      })
+    }
+    confirmedRef.current = false
+    setOpen(next)
+  }
+
   return (
-    <AlertDialog open={open} onOpenChange={setOpen}>
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle className="govuk-heading-l">
@@ -75,7 +88,10 @@ export const DeleteTemplatesDialog = ({
             type="button"
             className="govuk-button govuk-button--warning"
             disabled={isPending}
-            onClick={() => deleteTemplates(templateIds)}
+            onClick={() => {
+              confirmedRef.current = true
+              deleteTemplates(templateIds)
+            }}
           >
             Delete
           </button>

--- a/frontend/app/transcriptions/[transcriptionId]/MinuteTab/NewMinuteDialog.tsx
+++ b/frontend/app/transcriptions/[transcriptionId]/MinuteTab/NewMinuteDialog.tsx
@@ -89,6 +89,7 @@ export function NewMinuteDialog({
           })
           posthog.capture('generate_ai_minutes_started', {
             style: !!template.id ? 'User generated' : template.name,
+            transcriptionId,
           })
           setOpen(false)
           onCreated?.()

--- a/frontend/app/transcriptions/[transcriptionId]/MinuteTab/components/TranscriptionSidePanel.tsx
+++ b/frontend/app/transcriptions/[transcriptionId]/MinuteTab/components/TranscriptionSidePanel.tsx
@@ -7,6 +7,7 @@ import {
 import { useQuery } from '@tanstack/react-query'
 import Link from 'next/link'
 import { useParams, usePathname, useRouter } from 'next/navigation'
+import posthog from 'posthog-js'
 import { useState } from 'react'
 import { PanelLeftOpen, PanelLeftClose } from 'lucide-react'
 
@@ -110,7 +111,12 @@ export function TranscriptionSidePanel() {
       <button
         type="button"
         className="govuk-link govuk-link--no-visited-state govuk-link--no-underline govuk-!-margin-bottom-4 flex items-center gap-2 text-(--govuk-link-colour) xl:hidden"
-        onClick={() => setIsCollapsed((collapsed) => !collapsed)}
+        onClick={() => {
+          posthog.capture('sidebar_collapse_toggled', {
+            state: isCollapsed ? 'expanded' : 'collapsed',
+          })
+          setIsCollapsed((collapsed) => !collapsed)
+        }}
       >
         {isCollapsed ? (
           <>

--- a/frontend/app/transcriptions/[transcriptionId]/MinuteTab/components/delete-minute-button.tsx
+++ b/frontend/app/transcriptions/[transcriptionId]/MinuteTab/components/delete-minute-button.tsx
@@ -16,7 +16,7 @@ import {
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
 import posthog from 'posthog-js'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 export function DeleteMinuteButton({
   minute,
@@ -30,6 +30,7 @@ export function DeleteMinuteButton({
   const [open, setOpen] = useState(false)
   const queryClient = useQueryClient()
   const router = useRouter()
+  const confirmedRef = useRef(false)
   const { mutate: deleteMinute, isPending } = useMutation({
     ...deleteMinuteMinutesMinuteIdDeleteMutation(),
     onSuccess() {
@@ -47,6 +48,17 @@ export function DeleteMinuteButton({
     },
   })
 
+  const handleOpenChange = (next: boolean) => {
+    if (!next && !confirmedRef.current) {
+      posthog.capture('delete_modal_cancelled', {
+        entity_type: 'minute',
+        bulk: false,
+      })
+    }
+    confirmedRef.current = false
+    setOpen(next)
+  }
+
   return (
     <>
       <button
@@ -58,7 +70,7 @@ export function DeleteMinuteButton({
       >
         Delete summary
       </button>
-      <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialog open={open} onOpenChange={handleOpenChange}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle className="govuk-heading-l">
@@ -96,7 +108,10 @@ export function DeleteMinuteButton({
               type="button"
               className="govuk-button govuk-button--warning"
               disabled={isPending}
-              onClick={() => deleteMinute({ path: { minute_id: minute.id! } })}
+              onClick={() => {
+                confirmedRef.current = true
+                deleteMinute({ path: { minute_id: minute.id! } })
+              }}
             >
               Delete summary
             </button>

--- a/frontend/app/transcriptions/[transcriptionId]/MinuteTab/minute-editor/minute-editor.tsx
+++ b/frontend/app/transcriptions/[transcriptionId]/MinuteTab/minute-editor/minute-editor.tsx
@@ -161,6 +161,9 @@ export function MinuteEditor({
     (data: MinuteEditorForm) => {
       setEditBaseline(null)
       if (data.html != minuteVersion?.html_content) {
+        posthog.capture('summary_edited', {
+          transcriptionId: transcription.id,
+        })
         saveEdit(
           {
             path: { minute_id: minute.id! },
@@ -175,7 +178,13 @@ export function MinuteEditor({
         setIsEditable(false)
       }
     },
-    [minute.id, minuteVersion?.html_content, onSuccess, saveEdit]
+    [
+      minute.id,
+      minuteVersion?.html_content,
+      onSuccess,
+      saveEdit,
+      transcription.id,
+    ]
   )
   const onCancel = useCallback(async () => {
     const baseline = editBaseline

--- a/frontend/components/audio/mic-recorder.tsx
+++ b/frontend/components/audio/mic-recorder.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+import posthog from 'posthog-js'
+
 import RecordingControl from './recording-control'
 
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -204,6 +206,7 @@ function MicRecorderComponent({
       setIsRecording(true)
     } catch (micError) {
       console.warn('Error occurred starting audio recording.', micError)
+      posthog.capture('mic_start_failed', { source: 'mic_recorder' })
     }
     // Create a media recorder from the composed stream
   }, [

--- a/frontend/components/audio/tab-recorder/tab-recorder.tsx
+++ b/frontend/components/audio/tab-recorder/tab-recorder.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+import posthog from 'posthog-js'
+
 import { Alert, AlertDescription } from '@/components/ui/alert'
 
 import { DiscardConfirmDialog } from '@/components/audio/discard-dialog'
@@ -245,6 +247,10 @@ function TabRecorder({
           'Could not access microphone. Recording only tab audio.',
           micError
         )
+        posthog.capture('mic_start_failed', {
+          source: 'tab_recorder',
+          recording_continued: true,
+        })
       }
 
       const composedStream = new MediaStream()

--- a/frontend/components/navigation/guarded-link.tsx
+++ b/frontend/components/navigation/guarded-link.tsx
@@ -3,13 +3,14 @@
 import { useLockNavigationContext } from '@/hooks/use-lock-navigation-context'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
+import posthog from 'posthog-js'
 import { ComponentProps } from 'react'
 
 type GuardedLinkProps = ComponentProps<typeof Link>
 
 export const GuardedLink = ({ href, onClick, ...props }: GuardedLinkProps) => {
   const router = useRouter()
-  const { requestNavigation } = useLockNavigationContext()
+  const { lockNavigation, requestNavigation } = useLockNavigationContext()
 
   return (
     <Link
@@ -27,6 +28,11 @@ export const GuardedLink = ({ href, onClick, ...props }: GuardedLinkProps) => {
           props.target === '_blank'
         ) {
           return
+        }
+        if (lockNavigation) {
+          posthog.capture('guarded_link_clicked', {
+            destination: String(href),
+          })
         }
         // Always drive navigation through router.push so Link doesn't navigate
         // in parallel; requestNavigation runs it now or defers it behind the guard.

--- a/frontend/components/onboarding/onboarding-tour.tsx
+++ b/frontend/components/onboarding/onboarding-tour.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/hooks/use-onboarding-tour'
 import { EVENTS, STATUS } from 'react-joyride'
 import { usePathname } from 'next/navigation'
+import posthog from 'posthog-js'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 const UNAUTHORISED_PATH = '/unauthorised'
@@ -68,11 +69,23 @@ export function OnboardingTour() {
     run: tourActive,
     steps,
     onEvent: (data) => {
+      if (data.type === EVENTS.TOUR_START) {
+        posthog.capture('tour_started', { page: tourKey })
+      } else if (data.type === EVENTS.STEP_AFTER) {
+        posthog.capture('tour_step_viewed', {
+          page: tourKey,
+          step_index: data.index,
+        })
+      }
       if (
         data.type === EVENTS.TOUR_END ||
         data.status === STATUS.SKIPPED ||
         data.status === STATUS.FINISHED
       ) {
+        posthog.capture(
+          data.status === STATUS.FINISHED ? 'tour_completed' : 'tour_dismissed',
+          { page: tourKey, step_index: data.index }
+        )
         finishTour()
       }
     },

--- a/frontend/components/posthog-banner.tsx
+++ b/frontend/components/posthog-banner.tsx
@@ -2,6 +2,7 @@
 
 import { FeatureFlags } from '@/lib/feature-flags'
 import Link from 'next/link'
+import posthog from 'posthog-js'
 import { useFeatureFlagPayload } from 'posthog-js/react'
 
 export function PosthogBanner() {
@@ -20,6 +21,7 @@ export function PosthogBanner() {
   }
 
   const handleDismiss = () => {
+    posthog.capture('banner_dismissed')
     localStorage.setItem('posthog-banner-dismissed', payload.title || '')
     window.location.reload()
   }
@@ -41,7 +43,14 @@ export function PosthogBanner() {
           Dismiss
         </button>
       </div>
-      <details className="govuk-details govuk-!-margin-bottom-0">
+      <details
+        className="govuk-details govuk-!-margin-bottom-0"
+        onToggle={(e) => {
+          if (e.currentTarget.open) {
+            posthog.capture('posthog_banner_details_expanded')
+          }
+        }}
+      >
         <summary className="govuk-details__summary before:!text-white">
           <span className="govuk-details__summary-text !text-white">
             {payload.detailsText || 'See details'}

--- a/frontend/components/recent-meetings/delete-transcription-dialog.tsx
+++ b/frontend/components/recent-meetings/delete-transcription-dialog.tsx
@@ -17,7 +17,7 @@ import {
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { usePathname, useRouter } from 'next/navigation'
 import posthog from 'posthog-js'
-import { Dispatch, SetStateAction } from 'react'
+import { Dispatch, SetStateAction, useRef } from 'react'
 
 export type DeleteTranscription = {
   id: string
@@ -39,6 +39,7 @@ export const DeleteTranscriptionDialog = ({
   const queryClient = useQueryClient()
   const router = useRouter()
   const pathname = usePathname()
+  const confirmedRef = useRef(false)
   const { mutate: deleteTranscription, isPending } = useMutation({
     ...deleteTranscriptionTranscriptionsTranscriptionIdDeleteMutation(),
     onSuccess() {
@@ -58,6 +59,17 @@ export const DeleteTranscriptionDialog = ({
     },
   })
 
+  const handleOpenChange = (next: boolean) => {
+    if (!next && !confirmedRef.current) {
+      posthog.capture('delete_modal_cancelled', {
+        entity_type: 'transcription',
+        bulk: false,
+      })
+    }
+    confirmedRef.current = false
+    setOpen(next)
+  }
+
   const title =
     transcription.title ||
     (['awaiting_start', 'in_progress'].includes(transcription.status)
@@ -65,7 +77,7 @@ export const DeleteTranscriptionDialog = ({
       : 'No title')
 
   return (
-    <AlertDialog open={open} onOpenChange={setOpen}>
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle className="govuk-heading-l">
@@ -99,11 +111,12 @@ export const DeleteTranscriptionDialog = ({
             type="button"
             className="govuk-button govuk-button--warning"
             disabled={isPending}
-            onClick={() =>
+            onClick={() => {
+              confirmedRef.current = true
               deleteTranscription({
                 path: { transcription_id: transcription.id },
               })
-            }
+            }}
           >
             Delete transcription
           </button>

--- a/frontend/components/recent-meetings/delete-transcriptions-dialog.tsx
+++ b/frontend/components/recent-meetings/delete-transcriptions-dialog.tsx
@@ -13,7 +13,7 @@ import { listTranscriptionsTranscriptionsGetQueryKey } from '@/lib/client/@tanst
 import { deleteTranscriptionTranscriptionsTranscriptionIdDelete } from '@/lib/client/sdk.gen'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import posthog from 'posthog-js'
-import { Dispatch, SetStateAction } from 'react'
+import { Dispatch, SetStateAction, useRef } from 'react'
 
 export const DeleteTranscriptionsDialog = ({
   open,
@@ -29,6 +29,7 @@ export const DeleteTranscriptionsDialog = ({
   onDeleted: () => void
 }) => {
   const queryClient = useQueryClient()
+  const confirmedRef = useRef(false)
   const { mutate: deleteTranscriptions, isPending } = useMutation({
     mutationFn: async (ids: string[]) => {
       await Promise.all(
@@ -49,8 +50,20 @@ export const DeleteTranscriptionsDialog = ({
     },
   })
 
+  const handleOpenChange = (next: boolean) => {
+    if (!next && !confirmedRef.current) {
+      posthog.capture('delete_modal_cancelled', {
+        entity_type: 'transcription',
+        bulk: true,
+        count,
+      })
+    }
+    confirmedRef.current = false
+    setOpen(next)
+  }
+
   return (
-    <AlertDialog open={open} onOpenChange={setOpen}>
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle className="govuk-heading-l">
@@ -76,7 +89,10 @@ export const DeleteTranscriptionsDialog = ({
             type="button"
             className="govuk-button govuk-button--warning"
             disabled={isPending}
-            onClick={() => deleteTranscriptions(transcriptionIds)}
+            onClick={() => {
+              confirmedRef.current = true
+              deleteTranscriptions(transcriptionIds)
+            }}
           >
             Delete {count} selected
           </button>

--- a/frontend/components/recent-meetings/paginated-transcriptions.tsx
+++ b/frontend/components/recent-meetings/paginated-transcriptions.tsx
@@ -12,6 +12,7 @@ import { useRecordingDb } from '@/providers/transcription-db-provider'
 import { useQueryClient } from '@tanstack/react-query'
 import Link from 'next/link'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import posthog from 'posthog-js'
 import { useEffect, useRef, useState } from 'react'
 import { Search, FileText } from 'lucide-react'
 
@@ -213,7 +214,16 @@ export const PaginatedTranscriptions = () => {
         </form>
       </div>
       {visibleOfflineRecordings.length > 0 && (
-        <details className="govuk-details">
+        <details
+          className="govuk-details"
+          onToggle={(e) => {
+            if (e.currentTarget.open) {
+              posthog.capture('details_expanded', {
+                which: 'why_not_uploaded',
+              })
+            }
+          }}
+        >
           <summary className="govuk-details__summary">
             <span className="govuk-details__summary-text">
               Why are some recordings marked &quot;Not uploaded&quot;?

--- a/frontend/hooks/use-generate-summary-from-minute.ts
+++ b/frontend/hooks/use-generate-summary-from-minute.ts
@@ -41,6 +41,8 @@ export const useGenerateSummaryFromMinute = (transcriptionId: string) => {
       posthog.capture('generate_ai_minutes_started', {
         style: minute.template_name,
         source: 'speaker_editor',
+        transcriptionId,
+        isRegeneration: !!sourceMinuteId,
       })
       return minute
     },

--- a/frontend/hooks/use-lock-navigation-context.tsx
+++ b/frontend/hooks/use-lock-navigation-context.tsx
@@ -18,6 +18,7 @@ import {
   useRef,
   useState,
 } from 'react'
+import posthog from 'posthog-js'
 
 type LockNavigationContextType = {
   lockNavigation: boolean
@@ -59,6 +60,7 @@ export const LockNavigationProvider = ({
   const handleConfirm = useCallback(() => {
     const proceed = pendingRef.current
     pendingRef.current = null
+    posthog.capture('leave_recording_prompt_resolved', { outcome: 'left' })
     setOpen(false)
     setLockNavigation(false)
     proceed?.()
@@ -66,6 +68,7 @@ export const LockNavigationProvider = ({
 
   const handleCancel = useCallback(() => {
     pendingRef.current = null
+    posthog.capture('leave_recording_prompt_resolved', { outcome: 'stayed' })
     setOpen(false)
   }, [])
 

--- a/frontend/hooks/useStartTranscription.ts
+++ b/frontend/hooks/useStartTranscription.ts
@@ -38,14 +38,24 @@ export const useStartTranscription = (
       uploadUrl: string
       file: Blob | File
     }) => {
-      const uploadResponse = await fetch(uploadUrl, {
-        method: 'PUT',
-        body: file,
-        headers: {
-          'x-ms-blob-type': 'BlockBlob',
-        },
-      })
+      let uploadResponse: Response
+      try {
+        uploadResponse = await fetch(uploadUrl, {
+          method: 'PUT',
+          body: file,
+          headers: {
+            'x-ms-blob-type': 'BlockBlob',
+          },
+        })
+      } catch (error) {
+        posthog.capture('upload_failed', { failure_type: 'network' })
+        throw error
+      }
       if (!uploadResponse.ok) {
+        posthog.capture('upload_failed', {
+          failure_type: 'bad_response',
+          status: uploadResponse.status,
+        })
         throw new Error('Failed to upload file to S3')
       }
     },

--- a/frontend/providers/posthog.tsx
+++ b/frontend/providers/posthog.tsx
@@ -2,14 +2,34 @@
 
 import { getUserUsersMeGetOptions } from '@/lib/client/@tanstack/react-query.gen'
 import { useQuery } from '@tanstack/react-query'
+import { usePathname, useSearchParams } from 'next/navigation'
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
-import React from 'react'
+import React, { Suspense, useEffect, PropsWithChildren } from 'react'
 
-function PosthogProvider({ children }: React.PropsWithChildren) {
+function PageviewTracker() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    if (!posthog.__loaded) {
+      return
+    }
+    let url = window.origin + pathname
+    const search = searchParams.toString()
+    if (search) {
+      url = `${url}?${search}`
+    }
+    posthog.capture('$pageview', { $current_url: url })
+  }, [pathname, searchParams])
+
+  return null
+}
+
+function PosthogProvider({ children }: PropsWithChildren) {
   const { data: user } = useQuery({ ...getUserUsersMeGetOptions() })
 
-  React.useEffect(() => {
+  useEffect(() => {
     const API_KEY = process.env.NEXT_PUBLIC_POSTHOG_API_KEY
     if (!API_KEY) {
       return
@@ -19,6 +39,7 @@ function PosthogProvider({ children }: React.PropsWithChildren) {
       persistence: 'memory',
       autocapture: false,
       disable_session_recording: true,
+      capture_pageview: false,
     })
 
     if (user?.id) {
@@ -26,7 +47,14 @@ function PosthogProvider({ children }: React.PropsWithChildren) {
     }
   }, [user?.id])
 
-  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
+  return (
+    <PostHogProvider client={posthog}>
+      <Suspense fallback={null}>
+        <PageviewTracker />
+      </Suspense>
+      {children}
+    </PostHogProvider>
+  )
 }
 
 export default PosthogProvider


### PR DESCRIPTION
# Add PostHog analytics: funnel, failures, navigation

Events asked for can be found [here](https://incubatorforartificialintelligence.atlassian.net/wiki/spaces/~712020cae95c6d8e2c4db89cf7a023fd80036e/pages/305332440/Minute+analytics+sept+26)

## Events added

- $pageview — manual, on route change (URL-only, ID-based routes) - TO remove potential personal information from page titles
- generate_ai_minutes_started — added transcriptionId + isRegeneration
- summary_edited — { transcriptionId }
- upload_failed — { failure_type, status }
- mic_start_failed — { source }
- screen_share_cancelled
- delete_modal_cancelled — { entity_type, bulk } (all 4 delete dialogs)
- guarded_link_clicked — { destination } (recording in progress only)
- leave_recording_prompt_resolved — { outcome } (recording in progress only)
- sidebar_collapse_toggled — { state }
- details_expanded — { which }
- banner_dismissed
- posthog_banner_details_expanded
- tour_started / tour_step_viewed / tour_completed / tour_dismissed — { page, step_index }

## Events not added

- Transcription/summary success & failure — deferred to a backend PR. If only on frontend would only fire if the user stays on the status page until the generation is done
- Viewport dimensions — already on every event via PostHog's default $viewport_*.
- WAU/MAU/retention — derivable from identify.
- Per-session / per-URL breakdowns — derivable from $pageview.

## Edits after code review with Claude

- Scoped guarded_link_clicked to recording-in-progress only (was firing site-wide).
- Dropped properties now covered by default event data (pathname, viewport, banner title/timer).
- Moved sidebar-toggle capture out of the setState updater (dev StrictMode double-fire).
- Made mic_start_failed consistent across all three call sites.
- Added bulk: false to single delete dialogs for a clean boolean.
- Privacy: no event carries meeting-derived content; $pageview URL safe (ID-based routes).