### PR TITLE
Add posthog events to success and failed generation

### DIFF
--- a/common/services/minute_handler_service.py
+++ b/common/services/minute_handler_service.py
@@ -16,6 +16,7 @@ from common.prompts import (
     get_ai_edit_initial_messages,
     get_basic_minutes_prompt,
 )
+from common.services.posthog_client import capture_event
 from common.services.template_manager import TemplateManager
 from common.settings import get_settings
 from common.templates.user_template import generate_user_template
@@ -154,9 +155,19 @@ class MinuteHandlerService:
                 hallucinations=hallucinations,
                 status=JobStatus.COMPLETED,
             )
+            capture_event(
+                minute_version.minute.transcription.user_id,
+                "summary_generation_succeeded",
+                {"transcriptionId": str(minute_version.minute.transcription_id)},
+            )
         except Exception as e:
             logger.exception("%s: Minute generation failed", minute_version.minute_id)
             cls.record_minute_version_failure(minute_version.id, error=str(e))
+            capture_event(
+                minute_version.minute.transcription.user_id,
+                "summary_generation_failed",
+                {"transcriptionId": str(minute_version.minute.transcription_id)},
+            )
             raise MinuteGenerationFailedError from e
 
     @classmethod

--- a/common/services/posthog_client.py
+++ b/common/services/posthog_client.py
@@ -1,8 +1,33 @@
+import logging
+from typing import Any
+from uuid import UUID
+
 import posthog
 
 from common.settings import get_settings
+
+logger = logging.getLogger(__name__)
 
 settings = get_settings()
 posthog_client = None
 if settings.POSTHOG_API_KEY:
     posthog_client = posthog.Posthog(settings.POSTHOG_API_KEY, host=settings.POSTHOG_HOST)
+
+
+def capture_event(
+    distinct_id: UUID | str | None,
+    event: str,
+    properties: dict[str, Any] | None = None,
+) -> None:
+    """Capture a PostHog event from backend/worker code.
+
+    No-op when PostHog is not configured (e.g. local/tests) or the user is unknown.
+    Non-blocking: events are queued and sent by the client's background thread. Never
+    raises: analytics must not break job processing.
+    """
+    if posthog_client is None or distinct_id is None:
+        return
+    try:
+        posthog_client.capture(distinct_id=str(distinct_id), event=event, properties=properties or {})
+    except Exception:
+        logger.exception("Failed to capture PostHog event %s", event)

--- a/common/services/transcription_handler_service.py
+++ b/common/services/transcription_handler_service.py
@@ -11,6 +11,7 @@ from common.generate_meeting_title import generate_meeting_title
 from common.llm.client import FastOrBestLLM, create_default_chatbot
 from common.prompts import get_chat_with_transcript_system_message
 from common.services.exceptions import InteractionFailedError, TranscriptionFailedError
+from common.services.posthog_client import capture_event
 from common.services.transcription_services.transcription_manager import TranscriptionServiceManager
 from common.settings import get_settings
 from common.templates.citations import combine_consecutive_citations
@@ -168,6 +169,11 @@ class TranscriptionHandlerService:
                 cls.update_transcription(
                     transcription.id, status=JobStatus.COMPLETED, transcript=dialogue_entries, title=meeting_title
                 )
+                capture_event(
+                    transcription.user_id,
+                    "transcription_succeeded",
+                    {"transcriptionId": str(transcription.id)},
+                )
 
         except Exception as e:
             msg = f"Transcription failed: {e!s}"
@@ -177,6 +183,11 @@ class TranscriptionHandlerService:
             except Exception:
                 logger.exception("Error updating transcription status. Maybe it doesn't exist?")
 
+            capture_event(
+                transcription.user_id,
+                "transcription_failed",
+                {"transcriptionId": str(transcription.id)},
+            )
             raise TranscriptionFailedError from e
         else:
             return transcription_job

--- a/frontend/providers/posthog.tsx
+++ b/frontend/providers/posthog.tsx
@@ -2,14 +2,34 @@
 
 import { getUserUsersMeGetOptions } from '@/lib/client/@tanstack/react-query.gen'
 import { useQuery } from '@tanstack/react-query'
+import { usePathname, useSearchParams } from 'next/navigation'
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
-import React from 'react'
+import React, { Suspense, useEffect, PropsWithChildren } from 'react'
 
-function PosthogProvider({ children }: React.PropsWithChildren) {
+function PageviewTracker() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    if (!posthog.__loaded) {
+      return
+    }
+    let url = window.origin + pathname
+    const search = searchParams.toString()
+    if (search) {
+      url = `${url}?${search}`
+    }
+    posthog.capture('$pageview', { $current_url: url })
+  }, [pathname, searchParams])
+
+  return null
+}
+
+function PosthogProvider({ children }: PropsWithChildren) {
   const { data: user } = useQuery({ ...getUserUsersMeGetOptions() })
 
-  React.useEffect(() => {
+  useEffect(() => {
     const API_KEY = process.env.NEXT_PUBLIC_POSTHOG_API_KEY
     if (!API_KEY) {
       return
@@ -19,6 +39,7 @@ function PosthogProvider({ children }: React.PropsWithChildren) {
       persistence: 'memory',
       autocapture: false,
       disable_session_recording: true,
+      capture_pageview: false,
     })
 
     if (user?.id) {
@@ -26,7 +47,14 @@ function PosthogProvider({ children }: React.PropsWithChildren) {
     }
   }, [user?.id])
 
-  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
+  return (
+    <PostHogProvider client={posthog}>
+      <Suspense fallback={null}>
+        <PageviewTracker />
+      </Suspense>
+      {children}
+    </PostHogProvider>
+  )
 }
 
 export default PosthogProvider

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ worker = [
     "ray[default]>=2.53.0,<3",
     "azure-storage-blob>=12.26.0,<13",
     "azure-identity>=1.23.1,<2",
+    "posthog>=6.6.1,<7",
 ]
 dev = [
     "bumpversion>=0.6.0,<0.7",

--- a/uv.lock
+++ b/uv.lock
@@ -1203,6 +1203,7 @@ worker = [
     { name = "ffmpeg-python" },
     { name = "google-genai" },
     { name = "openai" },
+    { name = "posthog" },
     { name = "ray", extra = ["default"] },
 ]
 
@@ -1260,6 +1261,7 @@ worker = [
     { name = "ffmpeg-python", specifier = ">=0.2.0,<0.3" },
     { name = "google-genai", specifier = ">=1.10.0,<2" },
     { name = "openai", specifier = ">=1.42.0,<2" },
+    { name = "posthog", specifier = ">=6.6.1,<7" },
     { name = "ray", extras = ["default"], specifier = ">=2.53.0,<3" },
 ]
 


### PR DESCRIPTION
# Add backend outcome events for transcription & summary generation

## What this does

Fires the success/failure events [the frontend PR](https://github.com/i-dot-ai/minute/pull/153) left out, from the worker where the job finishes.

## Events added

- transcription_succeeded / transcription_failed — { transcriptionId }
- summary_generation_succeeded / summary_generation_failed — { transcriptionId }

Keyed on user_id to match the frontend, so started and outcome events attach to the same person.

## Why the worker, not the frontend

If left on the frontend, the user would have to stay on the status page until the success was fired in order to be captured

## On flushing

Decided not to  flush. The client queues events and sends them on a background thread within about half a second. Flushing is the only blocking call, and didn't want blocking network calls on the job path. 

The only cost is losing events queued in the last moment before a worker stops — negligible for one small event per job.

## Notes

- Adds posthog to the worker dependency group (was backend-only).
- capture_event is a no-op when PostHog isn't configured or the user is unknown, and never raises.